### PR TITLE
Add notice for StopTooFarFromTripShape validation rule

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -16,9 +16,6 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
-import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
-
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+
+import com.google.common.collect.ImmutableMap;
+
+public class StopTooFarFromTripShapeNotice extends Notice {
+    public StopTooFarFromTripShapeNotice(GtfsStopTime stopTime, GtfsTrip trip, double tripBufferMeters) {
+        super(ImmutableMap.of(
+            "stopId", stopTime.stopId(),
+            "stopSequence", stopTime.stopSequence(),
+            "tripId", trip.tripId(),
+            "shapeId", trip.shapeId(),
+            "tripBufferMeters", tripBufferMeters
+        ));
+    }
+
+    @Override
+    public String getCode() {
+        return "stop_too_far_from_trip_shape";
+    }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,13 +22,14 @@ public class StopTooFarFromTripShapeNotice extends Notice {
     // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be
     // added to support notice visualisation.
     public StopTooFarFromTripShapeNotice(
-        String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
-        super(ImmutableMap.of(
-            "stopId", stopId,
-            "stopSequence", stopSequence,
-            "tripId", tripId,
-            "shapeId", shapeId,
-            "tripBufferMeters", tripBufferMeters));
+            String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+        super(
+                ImmutableMap.of(
+                        "stopId", stopId,
+                        "stopSequence", stopSequence,
+                        "tripId", tripId,
+                        "shapeId", shapeId,
+                        "tripBufferMeters", tripBufferMeters));
     }
 
     @Override

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,12 +22,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    public StopTooFarFromTripShapeNotice(GtfsStopTime stopTime, GtfsTrip trip, double tripBufferMeters) {
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
-            "stopId", stopTime.stopId(),
-            "stopSequence", stopTime.stopSequence(),
-            "tripId", trip.tripId(),
-            "shapeId", trip.shapeId(),
+            "stopId", stopId,
+            "stopSequence", stopSequence,
+            "tripId", tripId,
+            "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters
         ));
     }

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -19,15 +19,16 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be added to support notice visualisation.
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be
+    // added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(
+        String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
             "tripId", tripId,
             "shapeId", shapeId,
-            "tripBufferMeters", tripBufferMeters
-        ));
+            "tripBufferMeters", tripBufferMeters));
     }
 
     @Override

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,13 +22,11 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    // TODO: More fields (e.g. information related to trip shape polygon) will be added to support notice visualisation.
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, double stopLat, double stopLon, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
-            "stopLat", stopLat,
-            "stopLon", stopLon,
             "tripId", tripId,
             "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,10 +22,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. information related to trip shape polygon) will be added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, double stopLat, double stopLon, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
+            "stopLat", stopLat,
+            "stopLon", stopLon,
             "tripId", tripId,
             "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters


### PR DESCRIPTION
**4 space** (rather than 2 space) is kept for all rules, notices and tests files to keep the coding style consistent with all existing (rules, notices and tests) files for the new validator.
The corresponding validation rule is in PR #8.