### PR TITLE
Add tests for the StopTooFarFromTripShapeValidator rule

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -16,9 +16,6 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
-import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
-
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+
+import com.google.common.collect.ImmutableMap;
+
+public class StopTooFarFromTripShapeNotice extends Notice {
+    public StopTooFarFromTripShapeNotice(GtfsStopTime stopTime, GtfsTrip trip, double tripBufferMeters) {
+        super(ImmutableMap.of(
+            "stopId", stopTime.stopId(),
+            "stopSequence", stopTime.stopSequence(),
+            "tripId", trip.tripId(),
+            "shapeId", trip.shapeId(),
+            "tripBufferMeters", tripBufferMeters
+        ));
+    }
+
+    @Override
+    public String getCode() {
+        return "stop_too_far_from_trip_shape";
+    }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,13 +22,14 @@ public class StopTooFarFromTripShapeNotice extends Notice {
     // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be
     // added to support notice visualisation.
     public StopTooFarFromTripShapeNotice(
-        String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
-        super(ImmutableMap.of(
-            "stopId", stopId,
-            "stopSequence", stopSequence,
-            "tripId", tripId,
-            "shapeId", shapeId,
-            "tripBufferMeters", tripBufferMeters));
+            String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+        super(
+                ImmutableMap.of(
+                        "stopId", stopId,
+                        "stopSequence", stopSequence,
+                        "tripId", tripId,
+                        "shapeId", shapeId,
+                        "tripBufferMeters", tripBufferMeters));
     }
 
     @Override

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,12 +22,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    public StopTooFarFromTripShapeNotice(GtfsStopTime stopTime, GtfsTrip trip, double tripBufferMeters) {
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
-            "stopId", stopTime.stopId(),
-            "stopSequence", stopTime.stopSequence(),
-            "tripId", trip.tripId(),
-            "shapeId", trip.shapeId(),
+            "stopId", stopId,
+            "stopSequence", stopSequence,
+            "tripId", tripId,
+            "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters
         ));
     }

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -19,15 +19,16 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be added to support notice visualisation.
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be
+    // added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(
+        String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
             "tripId", tripId,
             "shapeId", shapeId,
-            "tripBufferMeters", tripBufferMeters
-        ));
+            "tripBufferMeters", tripBufferMeters));
     }
 
     @Override

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,13 +22,11 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    // TODO: More fields (e.g. information related to trip shape polygon) will be added to support notice visualisation.
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, double stopLat, double stopLon, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. stop location & information related to trip shape polygon) will be added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
-            "stopLat", stopLat,
-            "stopLon", stopLon,
             "tripId", tripId,
             "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -22,10 +22,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import com.google.common.collect.ImmutableMap;
 
 public class StopTooFarFromTripShapeNotice extends Notice {
-    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, String tripId, String shapeId, double tripBufferMeters) {
+    // TODO: More fields (e.g. information related to trip shape polygon) will be added to support notice visualisation.
+    public StopTooFarFromTripShapeNotice(String stopId, int stopSequence, double stopLat, double stopLon, String tripId, String shapeId, double tripBufferMeters) {
         super(ImmutableMap.of(
             "stopId", stopId,
             "stopSequence", stopSequence,
+            "stopLat", stopLat,
+            "stopLon", stopLon,
             "tripId", tripId,
             "shapeId", shapeId,
             "tripBufferMeters", tripBufferMeters

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class StopTooFarFromTripShapeValidatorTest {
+
+    public static GtfsStop createStop(long csvRowNumber, String stopId, double stopLat, double stopLon, GtfsLocationType locationType) {
+        return new GtfsStop.Builder().setCsvRowNumber(csvRowNumber).setStopId(stopId).setStopLat(stopLat).setStopLon(stopLon).setLocationType(locationType.getNumber()).build();
+    }
+
+    public static GtfsStopTime createStopTime(long csvRowNumber, String tripId, String stopId, int stopSequence) {
+        return new GtfsStopTime.Builder().setCsvRowNumber(csvRowNumber).setTripId(tripId).setStopId(stopId).setStopSequence(stopSequence).build();
+    }
+
+    public static GtfsShape createShape(long csvRowNumber, String shapeId, double shapePtLat, double shapePtLon, int shapePtSequence) {
+        return new GtfsShape.Builder().setCsvRowNumber(csvRowNumber).setShapeId(shapeId).setShapePtLat(shapePtLat).setShapePtLon(shapePtLon).setShapePtSequence(shapePtSequence).build();
+    }
+
+    public static GtfsTrip createTrip(long csvRowNumber, String tripId, String shapeId) {
+        return new GtfsTrip.Builder().setCsvRowNumber(csvRowNumber).setTripId(tripId).setShapeId(shapeId).build();
+    }
+
+    private static GtfsStopTableContainer createStopTable(String[] stopIds, double[] stopLats, double[] stopLons, GtfsLocationType[] locationTypes, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(stopIds.length == stopLats.length, "stopIds.length must be equal to stopLats.length");
+        Preconditions.checkArgument(stopLats.length == stopLons.length, "stopLats.length must be equal to stopLons.length");
+        Preconditions.checkArgument(stopIds.length == locationTypes.length, "stopIds.length must be equal to locationTypes.length");
+        ArrayList<GtfsStop> stops = new ArrayList<>();
+        stops.ensureCapacity(stopIds.length);
+        for (int i = 0; i < stopIds.length; i++) {
+            stops.add(createStop(stops.size() + 1, stopIds[i], stopLats[i], stopLons[i], locationTypes[i]));
+        }
+        return GtfsStopTableContainer.forEntities(stops, noticeContainer);
+    }
+
+    private static GtfsStopTimeTableContainer createStopTimeTable(String[] tripIds, String[] stopIds, int[] stopSequences, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(tripIds.length == stopIds.length, "tripIds.length must be equal to stopIds.length");
+        Preconditions.checkArgument(stopIds.length == stopSequences.length, "stopIds.length must be equal to stopSequences.length");
+        ArrayList<GtfsStopTime> stopTimes = new ArrayList<>();
+        stopTimes.ensureCapacity(stopIds.length);
+        for (int i = 0; i < stopIds.length; i++) {
+            stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], stopIds[i], stopSequences[i]));
+        }
+        return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+    }
+
+    private static GtfsShapeTableContainer createShapeTable(String[] shapeIds, double[] shapePtLats, double[] shapePtLons, int[] shapePtSequences, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(shapeIds.length == shapePtLats.length, "shapeIds.length must be equal to shapePtLats.length");
+        Preconditions.checkArgument(shapePtLats.length == shapePtLons.length, "shapePtLats.length must be equal to shapePtLons.length");
+        Preconditions.checkArgument(shapeIds.length == shapePtSequences.length, "shapeIds.length must be equal to shapePtSequences.length");
+        ArrayList<GtfsShape> shapes = new ArrayList<>();
+        shapes.ensureCapacity(shapePtLats.length);
+        for (int i = 0; i < shapePtLats.length; i++) {
+            shapes.add(createShape(shapes.size() + 1, shapeIds[i], shapePtLats[i], shapePtLons[i], shapePtSequences[i]));
+        }
+        return GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
+    }
+
+    private static GtfsTripTableContainer createTripTable(String[] tripIds, String[] shapeIds, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(tripIds.length == shapeIds.length, "tripIds.length must be equal to shapeIds.length");
+        ArrayList<GtfsTrip> trips = new ArrayList<>();
+        trips.ensureCapacity(tripIds.length);
+        for (int i = 0; i < tripIds.length; i++) {
+            trips.add(createTrip(trips.size() + 1, tripIds[i], shapeIds[i]));
+        }
+        return GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    }
+
+    @Test
+    public void stopWithinTripShapeShouldNotGenerateNotice() {
+        // See map of trip shape and stops (in GeoJSON) at https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+        final NoticeContainer noticeContainer = new NoticeContainer();
+        StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
+        validator.stopTable = createStopTable(
+            new String[]{"1001", "1002"},
+            new double[]{28.05811731042478d, 28.05812364854794d},
+            new double[]{-82.41616877502503d, -82.41617370439423d},
+            new GtfsLocationType[]{GtfsLocationType.STOP, GtfsLocationType.STOP},
+            noticeContainer);
+        validator.stopTimeTable = createStopTimeTable(
+            new String[]{"trip1", "trip1"},
+            new String[]{"1001", "1002"},
+            new int[]{1, 2},
+            noticeContainer);
+        validator.shapeTable = createShapeTable(
+            new String[]{"shape1", "shape1", "shape1", "shape1", "shape1"},
+            new double[]{28.05724310653972d, 28.05746701492806d, 28.05800068503469d, 28.05808869825447d, 28.05809979887893d},
+            new double[]{-82.41350776611507d, -82.41493135129478d, -82.4159394137605d, -82.41648754043338d, -82.41773971025437d},
+            new int[]{1, 2, 3, 4, 5},
+            noticeContainer);
+        validator.tripTable = createTripTable(
+            new String[]{"trip1"},
+            new String[]{"shape1"},
+            noticeContainer);
+        validator.validate(noticeContainer);
+        assertThat(noticeContainer.getNotices()).isEmpty();
+    }
+
+    @Test
+    public void stopOutsideTripShapeShouldGenerateNotice() {
+        // See map of trip shape and stops (in GeoJSON) at https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+        final NoticeContainer noticeContainer = new NoticeContainer();
+        StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
+        validator.stopTable = createStopTable(
+            // stopId "1003" is the location OUTSIDE buffer.
+            new String[]{"1001", "1002", "1003"},
+            new double[]{28.05811731042478d, 28.05812364854794d, 28.05673053256373d},
+            new double[]{-82.41616877502503d, -82.41617370439423d, -82.4170801432763d},
+            new GtfsLocationType[]{GtfsLocationType.STOP, GtfsLocationType.STOP, GtfsLocationType.STOP},
+            noticeContainer);
+        validator.stopTimeTable = createStopTimeTable(
+            new String[]{"trip1", "trip1", "trip1"},
+            new String[]{"1001", "1002", "1003"},
+            new int[]{1, 2, 3},
+            noticeContainer);
+        validator.shapeTable = createShapeTable(
+            new String[]{"shape1", "shape1", "shape1", "shape1", "shape1"},
+            new double[]{28.05724310653972d, 28.05746701492806d, 28.05800068503469d, 28.05808869825447d, 28.05809979887893d},
+            new double[]{-82.41350776611507d, -82.41493135129478d, -82.4159394137605d, -82.41648754043338d, -82.41773971025437d},
+            new int[]{1, 2, 3, 4, 5},
+            noticeContainer);
+        validator.tripTable = createTripTable(
+            new String[]{"trip1"},
+            new String[]{"shape1"},
+            noticeContainer);
+        validator.validate(noticeContainer);
+        assertThat(noticeContainer.getNotices()).containsExactly(
+            new StopTooFarFromTripShapeNotice("1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
+        );
+    }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -38,98 +37,52 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 @RunWith(JUnit4.class)
 public class StopTooFarFromTripShapeValidatorTest {
-    public static GtfsStop createStop(long csvRowNumber, String stopId, double stopLat,
-            double stopLon, GtfsLocationType locationType) {
+    public static GtfsStop createStop(
+            long csvRowNumber,
+            String stopId,
+            double stopLat,
+            double stopLon,
+            GtfsLocationType locationType) {
         return new GtfsStop.Builder()
-            .setCsvRowNumber(csvRowNumber)
-            .setStopId(stopId)
-            .setStopLat(stopLat)
-            .setStopLon(stopLon)
-            .setLocationType(locationType.getNumber())
-            .build();
+                .setCsvRowNumber(csvRowNumber)
+                .setStopId(stopId)
+                .setStopLat(stopLat)
+                .setStopLon(stopLon)
+                .setLocationType(locationType.getNumber())
+                .build();
     }
 
     public static GtfsStopTime createStopTime(
             long csvRowNumber, String tripId, String stopId, int stopSequence) {
         return new GtfsStopTime.Builder()
-            .setCsvRowNumber(csvRowNumber)
-            .setTripId(tripId)
-            .setStopId(stopId)
-            .setStopSequence(stopSequence)
-            .build();
+                .setCsvRowNumber(csvRowNumber)
+                .setTripId(tripId)
+                .setStopId(stopId)
+                .setStopSequence(stopSequence)
+                .build();
     }
 
-    public static GtfsShape createShape(long csvRowNumber, String shapeId, double shapePtLat,
-            double shapePtLon, int shapePtSequence) {
+    public static GtfsShape createShape(
+            long csvRowNumber,
+            String shapeId,
+            double shapePtLat,
+            double shapePtLon,
+            int shapePtSequence) {
         return new GtfsShape.Builder()
-            .setCsvRowNumber(csvRowNumber)
-            .setShapeId(shapeId)
-            .setShapePtLat(shapePtLat)
-            .setShapePtLon(shapePtLon)
-            .setShapePtSequence(shapePtSequence)
-            .build();
+                .setCsvRowNumber(csvRowNumber)
+                .setShapeId(shapeId)
+                .setShapePtLat(shapePtLat)
+                .setShapePtLon(shapePtLon)
+                .setShapePtSequence(shapePtSequence)
+                .build();
     }
 
     public static GtfsTrip createTrip(long csvRowNumber, String tripId, String shapeId) {
         return new GtfsTrip.Builder()
-            .setCsvRowNumber(csvRowNumber)
-            .setTripId(tripId)
-            .setShapeId(shapeId)
-            .build();
-    }
-
-    private static GtfsStopTableContainer createStopTable(String[] stopIds, double[] stopLats,
-            double[] stopLons, GtfsLocationType[] locationTypes, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(
-            stopIds.length == stopLats.length, "stopIds.length must be equal to stopLats.length");
-        Preconditions.checkArgument(
-            stopLats.length == stopLons.length, "stopLats.length must be equal to stopLons.length");
-        Preconditions.checkArgument(
-            stopIds.length == locationTypes.length, "stopIds.length must be equal to locationTypes.length");
-        List<GtfsStop> stops = new ArrayList<>();
-        for (int i = 0; i < stopIds.length; i++) {
-            stops.add(createStop(stops.size() + 1, stopIds[i], stopLats[i], stopLons[i], locationTypes[i]));
-        }
-        return GtfsStopTableContainer.forEntities(stops, noticeContainer);
-    }
-
-    private static GtfsStopTimeTableContainer createStopTimeTable(
-            String[] tripIds, String[] stopIds, int[] stopSequences, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(
-            tripIds.length == stopIds.length, "tripIds.length must be equal to stopIds.length");
-        Preconditions.checkArgument(
-            stopIds.length == stopSequences.length, "stopIds.length must be equal to stopSequences.length");
-        List<GtfsStopTime> stopTimes = new ArrayList<>();
-        for (int i = 0; i < stopIds.length; i++) {
-            stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], stopIds[i], stopSequences[i]));
-        }
-        return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
-    }
-
-    private static GtfsShapeTableContainer createShapeTable(String[] shapeIds, double[] shapePtLats,
-            double[] shapePtLons, int[] shapePtSequences, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(
-            shapeIds.length == shapePtLats.length, "shapeIds.length must be equal to shapePtLats.length");
-        Preconditions.checkArgument(
-            shapePtLats.length == shapePtLons.length, "shapePtLats.length must be equal to shapePtLons.length");
-        Preconditions.checkArgument(
-            shapeIds.length == shapePtSequences.length, "shapeIds.length must be equal to shapePtSequences.length");
-        List<GtfsShape> shapes = new ArrayList<>();
-        for (int i = 0; i < shapePtLats.length; i++) {
-            shapes.add(createShape(shapes.size() + 1, shapeIds[i], shapePtLats[i], shapePtLons[i], shapePtSequences[i]));
-        }
-        return GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
-    }
-
-    private static GtfsTripTableContainer createTripTable(
-            String[] tripIds, String[] shapeIds, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(
-            tripIds.length == shapeIds.length, "tripIds.length must be equal to shapeIds.length");
-        List<GtfsTrip> trips = new ArrayList<>();
-        for (int i = 0; i < tripIds.length; i++) {
-            trips.add(createTrip(trips.size() + 1, tripIds[i], shapeIds[i]));
-        }
-        return GtfsTripTableContainer.forEntities(trips, noticeContainer);
+                .setCsvRowNumber(csvRowNumber)
+                .setTripId(tripId)
+                .setShapeId(shapeId)
+                .build();
     }
 
     @Test
@@ -138,33 +91,35 @@ public class StopTooFarFromTripShapeValidatorTest {
         // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
         final NoticeContainer noticeContainer = new NoticeContainer();
         StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
-        validator.stopTable = 
-            createStopTable(
-                new String[] {"1001", "1002"},
-                new double[] {28.05811731042478d, 28.05812364854794d},
-                new double[] {-82.41616877502503d, -82.41617370439423d},
-                new GtfsLocationType[] {GtfsLocationType.STOP, GtfsLocationType.STOP}, 
-                noticeContainer);
-        validator.stopTimeTable = 
-            createStopTimeTable(
-                new String[] {"trip1", "trip1"},
-                new String[] {"1001", "1002"},
-                new int[] {1, 2}, 
-                noticeContainer);
-        validator.shapeTable = 
-            createShapeTable(
-                new String[] {"shape1", "shape1", "shape1", "shape1", "shape1"},
-                new double[] {28.05724310653972d, 28.05746701492806d, 28.05800068503469d,
-                    28.05808869825447d, 28.05809979887893d},
-                new double[] {-82.41350776611507d, -82.41493135129478d, -82.4159394137605d,
-                    -82.41648754043338d, -82.41773971025437d},
-                new int[] {1, 2, 3, 4, 5}, 
-                noticeContainer);
-        validator.tripTable = 
-            createTripTable(
-                new String[] {"trip1"}, 
-                new String[] {"shape1"}, 
-                noticeContainer);
+
+        // Create stopTable:
+        List<GtfsStop> stops = new ArrayList<>();
+        stops.add(
+                createStop(1, "1001", 28.05811731042478d, -82.41616877502503d, GtfsLocationType.STOP));
+        stops.add(
+                createStop(2, "1002", 28.05812364854794d, -82.41617370439423d, GtfsLocationType.STOP));
+        validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
+
+        // Create stopTimeTable:
+        List<GtfsStopTime> stopTimes = new ArrayList<>();
+        stopTimes.add(createStopTime(1, "trip1", "1001", 1));
+        stopTimes.add(createStopTime(2, "trip1", "1002", 2));
+        validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+
+        // Create shapeTable:
+        List<GtfsShape> shapes = new ArrayList<>();
+        shapes.add(createShape(1, "shape1", 28.05724310653972d, -82.41350776611507d, 1));
+        shapes.add(createShape(2, "shape1", 28.05746701492806d, -82.41493135129478d, 2));
+        shapes.add(createShape(3, "shape1", 28.05800068503469d, -82.4159394137605d, 3));
+        shapes.add(createShape(4, "shape1", 28.05808869825447d, -82.41648754043338d, 4));
+        shapes.add(createShape(5, "shape1", 28.05809979887893d, -82.41773971025437d, 5));
+        validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
+
+        // Create tripTable:
+        List<GtfsTrip> trips = new ArrayList<>();
+        trips.add(createTrip(1, "trip1", "shape1"));
+        validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices()).isEmpty();
     }
@@ -175,39 +130,42 @@ public class StopTooFarFromTripShapeValidatorTest {
         // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
         final NoticeContainer noticeContainer = new NoticeContainer();
         StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
-        validator.stopTable = 
-            createStopTable(
-                // stopId "1003" is the location OUTSIDE buffer.
-                new String[] {"1001", "1002", "1003"},
-                new double[] {28.05811731042478d, 28.05812364854794d, 28.05673053256373d},
-                new double[] {-82.41616877502503d, -82.41617370439423d, -82.4170801432763d},
-                new GtfsLocationType[] {
-                    GtfsLocationType.STOP, GtfsLocationType.STOP, GtfsLocationType.STOP},
-                noticeContainer);
-        validator.stopTimeTable = 
-            createStopTimeTable(
-                new String[] {"trip1", "trip1", "trip1"},
-                new String[] {"1001", "1002", "1003"}, 
-                new int[] {1, 2, 3}, 
-                noticeContainer);
-        validator.shapeTable =
-            createShapeTable(
-                new String[] {"shape1", "shape1", "shape1", "shape1", "shape1"},
-                new double[] {28.05724310653972d, 28.05746701492806d, 28.05800068503469d,
-                    28.05808869825447d, 28.05809979887893d},
-                new double[] {-82.41350776611507d, -82.41493135129478d, -82.4159394137605d,
-                    -82.41648754043338d, -82.41773971025437d},
-                new int[] {1, 2, 3, 4, 5}, 
-                noticeContainer);
-        validator.tripTable =
-            createTripTable(
-                new String[] {"trip1"}, 
-                new String[] {"shape1"}, 
-                noticeContainer);
+
+        // Create stopTable:
+        List<GtfsStop> stops = new ArrayList<>();
+        stops.add(
+                createStop(1, "1001", 28.05811731042478d, -82.41616877502503d, GtfsLocationType.STOP));
+        stops.add(
+                createStop(2, "1002", 28.05812364854794d, -82.41617370439423d, GtfsLocationType.STOP));
+        // stopId "1003" is the location OUTSIDE buffer.
+        stops.add(createStop(3, "1003", 28.05673053256373d, -82.4170801432763d, GtfsLocationType.STOP));
+        validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
+
+        // Create stopTimeTable:
+        List<GtfsStopTime> stopTimes = new ArrayList<>();
+        stopTimes.add(createStopTime(1, "trip1", "1001", 1));
+        stopTimes.add(createStopTime(2, "trip1", "1002", 2));
+        stopTimes.add(createStopTime(3, "trip1", "1003", 3));
+        validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+
+        // Create shapeTable:
+        List<GtfsShape> shapes = new ArrayList<>();
+        shapes.add(createShape(1, "shape1", 28.05724310653972d, -82.41350776611507d, 1));
+        shapes.add(createShape(2, "shape1", 28.05746701492806d, -82.41493135129478d, 2));
+        shapes.add(createShape(3, "shape1", 28.05800068503469d, -82.4159394137605d, 3));
+        shapes.add(createShape(4, "shape1", 28.05808869825447d, -82.41648754043338d, 4));
+        shapes.add(createShape(5, "shape1", 28.05809979887893d, -82.41773971025437d, 5));
+        validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
+
+        // Create tripTable:
+        List<GtfsTrip> trips = new ArrayList<>();
+        trips.add(createTrip(1, "trip1", "shape1"));
+        validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices())
-            .containsExactly(
-                new StopTooFarFromTripShapeNotice(
-                    "1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS));
+                .containsExactly(
+                        new StopTooFarFromTripShapeNotice(
+                                "1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS));
     }
 }

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -37,53 +37,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 @RunWith(JUnit4.class)
 public class StopTooFarFromTripShapeValidatorTest {
-    public static GtfsStop createStop(
-            long csvRowNumber,
-            String stopId,
-            double stopLat,
-            double stopLon,
-            GtfsLocationType locationType) {
-        return new GtfsStop.Builder()
-                .setCsvRowNumber(csvRowNumber)
-                .setStopId(stopId)
-                .setStopLat(stopLat)
-                .setStopLon(stopLon)
-                .setLocationType(locationType.getNumber())
-                .build();
-    }
-
-    public static GtfsStopTime createStopTime(
-            long csvRowNumber, String tripId, String stopId, int stopSequence) {
-        return new GtfsStopTime.Builder()
-                .setCsvRowNumber(csvRowNumber)
-                .setTripId(tripId)
-                .setStopId(stopId)
-                .setStopSequence(stopSequence)
-                .build();
-    }
-
-    public static GtfsShape createShape(
-            long csvRowNumber,
-            String shapeId,
-            double shapePtLat,
-            double shapePtLon,
-            int shapePtSequence) {
-        return new GtfsShape.Builder()
-                .setCsvRowNumber(csvRowNumber)
-                .setShapeId(shapeId)
-                .setShapePtLat(shapePtLat)
-                .setShapePtLon(shapePtLon)
-                .setShapePtSequence(shapePtSequence)
-                .build();
-    }
-
-    public static GtfsTrip createTrip(long csvRowNumber, String tripId, String shapeId) {
-        return new GtfsTrip.Builder()
-                .setCsvRowNumber(csvRowNumber)
-                .setTripId(tripId)
-                .setShapeId(shapeId)
-                .build();
-    }
 
     @Test
     public void stopWithinTripShapeShouldNotGenerateNotice() {
@@ -95,29 +48,89 @@ public class StopTooFarFromTripShapeValidatorTest {
         // Create stopTable:
         List<GtfsStop> stops = new ArrayList<>();
         stops.add(
-                createStop(1, "1001", 28.05811731042478d, -82.41616877502503d, GtfsLocationType.STOP));
+                new GtfsStop.Builder()
+                        .setCsvRowNumber(1)
+                        .setStopId("1001")
+                        .setStopLat(28.05811731042478d)
+                        .setStopLon(-82.41616877502503d)
+                        .setLocationType(GtfsLocationType.STOP.getNumber())
+                        .build());
         stops.add(
-                createStop(2, "1002", 28.05812364854794d, -82.41617370439423d, GtfsLocationType.STOP));
+                new GtfsStop.Builder()
+                        .setCsvRowNumber(2)
+                        .setStopId("1002")
+                        .setStopLat(28.05812364854794d)
+                        .setStopLon(-82.41617370439423d)
+                        .setLocationType(GtfsLocationType.STOP.getNumber())
+                        .build());
         validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
 
         // Create stopTimeTable:
         List<GtfsStopTime> stopTimes = new ArrayList<>();
-        stopTimes.add(createStopTime(1, "trip1", "1001", 1));
-        stopTimes.add(createStopTime(2, "trip1", "1002", 2));
+        stopTimes.add(
+                new GtfsStopTime.Builder()
+                        .setCsvRowNumber(1)
+                        .setTripId("trip1")
+                        .setStopId("1001")
+                        .setStopSequence(1)
+                        .build());
+        stopTimes.add(
+                new GtfsStopTime.Builder()
+                        .setCsvRowNumber(2)
+                        .setTripId("trip1")
+                        .setStopId("1002")
+                        .setStopSequence(2)
+                        .build());
         validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
 
         // Create shapeTable:
         List<GtfsShape> shapes = new ArrayList<>();
-        shapes.add(createShape(1, "shape1", 28.05724310653972d, -82.41350776611507d, 1));
-        shapes.add(createShape(2, "shape1", 28.05746701492806d, -82.41493135129478d, 2));
-        shapes.add(createShape(3, "shape1", 28.05800068503469d, -82.4159394137605d, 3));
-        shapes.add(createShape(4, "shape1", 28.05808869825447d, -82.41648754043338d, 4));
-        shapes.add(createShape(5, "shape1", 28.05809979887893d, -82.41773971025437d, 5));
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(1)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05724310653972d)
+                        .setShapePtLon(-82.41350776611507d)
+                        .setShapePtSequence(1)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(2)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05746701492806d)
+                        .setShapePtLon(-82.41493135129478d)
+                        .setShapePtSequence(2)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(3)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05800068503469d)
+                        .setShapePtLon(-82.4159394137605d)
+                        .setShapePtSequence(3)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(4)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05808869825447d)
+                        .setShapePtLon(-82.41648754043338d)
+                        .setShapePtSequence(4)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(5)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05809979887893d)
+                        .setShapePtLon(-82.41773971025437d)
+                        .setShapePtSequence(5)
+                        .build());
         validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
 
         // Create tripTable:
         List<GtfsTrip> trips = new ArrayList<>();
-        trips.add(createTrip(1, "trip1", "shape1"));
+        trips.add(
+                new GtfsTrip.Builder().setCsvRowNumber(1).setTripId("trip1").setShapeId("shape1").build());
         validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
 
         validator.validate(noticeContainer);
@@ -134,32 +147,105 @@ public class StopTooFarFromTripShapeValidatorTest {
         // Create stopTable:
         List<GtfsStop> stops = new ArrayList<>();
         stops.add(
-                createStop(1, "1001", 28.05811731042478d, -82.41616877502503d, GtfsLocationType.STOP));
+                new GtfsStop.Builder()
+                        .setCsvRowNumber(1)
+                        .setStopId("1001")
+                        .setStopLat(28.05811731042478d)
+                        .setStopLon(-82.41616877502503d)
+                        .setLocationType(GtfsLocationType.STOP.getNumber())
+                        .build());
         stops.add(
-                createStop(2, "1002", 28.05812364854794d, -82.41617370439423d, GtfsLocationType.STOP));
+                new GtfsStop.Builder()
+                        .setCsvRowNumber(2)
+                        .setStopId("1002")
+                        .setStopLat(28.05812364854794d)
+                        .setStopLon(-82.41617370439423d)
+                        .setLocationType(GtfsLocationType.STOP.getNumber())
+                        .build());
         // stopId "1003" is the location OUTSIDE buffer.
-        stops.add(createStop(3, "1003", 28.05673053256373d, -82.4170801432763d, GtfsLocationType.STOP));
+        stops.add(
+                new GtfsStop.Builder()
+                        .setCsvRowNumber(3)
+                        .setStopId("1003")
+                        .setStopLat(28.05673053256373d)
+                        .setStopLon(-82.4170801432763d)
+                        .setLocationType(GtfsLocationType.STOP.getNumber())
+                        .build());
         validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
 
         // Create stopTimeTable:
         List<GtfsStopTime> stopTimes = new ArrayList<>();
-        stopTimes.add(createStopTime(1, "trip1", "1001", 1));
-        stopTimes.add(createStopTime(2, "trip1", "1002", 2));
-        stopTimes.add(createStopTime(3, "trip1", "1003", 3));
+        stopTimes.add(
+                new GtfsStopTime.Builder()
+                        .setCsvRowNumber(1)
+                        .setTripId("trip1")
+                        .setStopId("1001")
+                        .setStopSequence(1)
+                        .build());
+        stopTimes.add(
+                new GtfsStopTime.Builder()
+                        .setCsvRowNumber(2)
+                        .setTripId("trip1")
+                        .setStopId("1002")
+                        .setStopSequence(2)
+                        .build());
+        stopTimes.add(
+                new GtfsStopTime.Builder()
+                        .setCsvRowNumber(3)
+                        .setTripId("trip1")
+                        .setStopId("1003")
+                        .setStopSequence(3)
+                        .build());
         validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
 
         // Create shapeTable:
         List<GtfsShape> shapes = new ArrayList<>();
-        shapes.add(createShape(1, "shape1", 28.05724310653972d, -82.41350776611507d, 1));
-        shapes.add(createShape(2, "shape1", 28.05746701492806d, -82.41493135129478d, 2));
-        shapes.add(createShape(3, "shape1", 28.05800068503469d, -82.4159394137605d, 3));
-        shapes.add(createShape(4, "shape1", 28.05808869825447d, -82.41648754043338d, 4));
-        shapes.add(createShape(5, "shape1", 28.05809979887893d, -82.41773971025437d, 5));
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(1)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05724310653972d)
+                        .setShapePtLon(-82.41350776611507d)
+                        .setShapePtSequence(1)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(2)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05746701492806d)
+                        .setShapePtLon(-82.41493135129478d)
+                        .setShapePtSequence(2)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(3)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05800068503469d)
+                        .setShapePtLon(-82.4159394137605d)
+                        .setShapePtSequence(3)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(4)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05808869825447d)
+                        .setShapePtLon(-82.41648754043338d)
+                        .setShapePtSequence(4)
+                        .build());
+        shapes.add(
+                new GtfsShape.Builder()
+                        .setCsvRowNumber(5)
+                        .setShapeId("shape1")
+                        .setShapePtLat(28.05809979887893d)
+                        .setShapePtLon(-82.41773971025437d)
+                        .setShapePtSequence(5)
+                        .build());
         validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
 
         // Create tripTable:
         List<GtfsTrip> trips = new ArrayList<>();
-        trips.add(createTrip(1, "trip1", "shape1"));
+        trips.add(
+                new GtfsTrip.Builder().setCsvRowNumber(1).setTripId("trip1").setShapeId("shape1").build());
         validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
 
         validator.validate(noticeContainer);

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -158,7 +158,7 @@ public class StopTooFarFromTripShapeValidatorTest {
             noticeContainer);
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices()).containsExactly(
-            new StopTooFarFromTripShapeNotice("1003", 3, 28.05673053256373d, -82.4170801432763d, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
+            new StopTooFarFromTripShapeNotice("1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
         );
     }
 }

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import com.google.common.base.Preconditions;
+import java.util.List;
 import java.util.ArrayList;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
@@ -58,8 +59,7 @@ public class StopTooFarFromTripShapeValidatorTest {
         Preconditions.checkArgument(stopIds.length == stopLats.length, "stopIds.length must be equal to stopLats.length");
         Preconditions.checkArgument(stopLats.length == stopLons.length, "stopLats.length must be equal to stopLons.length");
         Preconditions.checkArgument(stopIds.length == locationTypes.length, "stopIds.length must be equal to locationTypes.length");
-        ArrayList<GtfsStop> stops = new ArrayList<>();
-        stops.ensureCapacity(stopIds.length);
+        List<GtfsStop> stops = new ArrayList<>();
         for (int i = 0; i < stopIds.length; i++) {
             stops.add(createStop(stops.size() + 1, stopIds[i], stopLats[i], stopLons[i], locationTypes[i]));
         }
@@ -69,8 +69,7 @@ public class StopTooFarFromTripShapeValidatorTest {
     private static GtfsStopTimeTableContainer createStopTimeTable(String[] tripIds, String[] stopIds, int[] stopSequences, NoticeContainer noticeContainer) {
         Preconditions.checkArgument(tripIds.length == stopIds.length, "tripIds.length must be equal to stopIds.length");
         Preconditions.checkArgument(stopIds.length == stopSequences.length, "stopIds.length must be equal to stopSequences.length");
-        ArrayList<GtfsStopTime> stopTimes = new ArrayList<>();
-        stopTimes.ensureCapacity(stopIds.length);
+        List<GtfsStopTime> stopTimes = new ArrayList<>();
         for (int i = 0; i < stopIds.length; i++) {
             stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], stopIds[i], stopSequences[i]));
         }
@@ -81,8 +80,7 @@ public class StopTooFarFromTripShapeValidatorTest {
         Preconditions.checkArgument(shapeIds.length == shapePtLats.length, "shapeIds.length must be equal to shapePtLats.length");
         Preconditions.checkArgument(shapePtLats.length == shapePtLons.length, "shapePtLats.length must be equal to shapePtLons.length");
         Preconditions.checkArgument(shapeIds.length == shapePtSequences.length, "shapeIds.length must be equal to shapePtSequences.length");
-        ArrayList<GtfsShape> shapes = new ArrayList<>();
-        shapes.ensureCapacity(shapePtLats.length);
+        List<GtfsShape> shapes = new ArrayList<>();
         for (int i = 0; i < shapePtLats.length; i++) {
             shapes.add(createShape(shapes.size() + 1, shapeIds[i], shapePtLats[i], shapePtLons[i], shapePtSequences[i]));
         }
@@ -91,8 +89,7 @@ public class StopTooFarFromTripShapeValidatorTest {
 
     private static GtfsTripTableContainer createTripTable(String[] tripIds, String[] shapeIds, NoticeContainer noticeContainer) {
         Preconditions.checkArgument(tripIds.length == shapeIds.length, "tripIds.length must be equal to shapeIds.length");
-        ArrayList<GtfsTrip> trips = new ArrayList<>();
-        trips.ensureCapacity(tripIds.length);
+        List<GtfsTrip> trips = new ArrayList<>();
         for (int i = 0; i < tripIds.length; i++) {
             trips.add(createTrip(trips.size() + 1, tripIds[i], shapeIds[i]));
         }

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -37,6 +37,96 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 @RunWith(JUnit4.class)
 public class StopTooFarFromTripShapeValidatorTest {
+    private final GtfsStop insideBufferStop1 =
+            new GtfsStop.Builder()
+                    .setCsvRowNumber(1)
+                    .setStopId("1001")
+                    .setStopLat(28.05811731042478d)
+                    .setStopLon(-82.41616877502503d)
+                    .setLocationType(GtfsLocationType.STOP.getNumber())
+                    .build();
+    private final GtfsStop insideBufferStop2 =
+            new GtfsStop.Builder()
+                    .setCsvRowNumber(2)
+                    .setStopId("1002")
+                    .setStopLat(28.05812364854794d)
+                    .setStopLon(-82.41617370439423d)
+                    .setLocationType(GtfsLocationType.STOP.getNumber())
+                    .build();
+    private final GtfsStop outsideBufferStop =
+            new GtfsStop.Builder()
+                    .setCsvRowNumber(3)
+                    .setStopId("1003")
+                    .setStopLat(28.05673053256373d)
+                    .setStopLon(-82.4170801432763d)
+                    .setLocationType(GtfsLocationType.STOP.getNumber())
+                    .build();
+
+    private final GtfsStopTime insideBufferStopTime1 =
+            new GtfsStopTime.Builder()
+                    .setCsvRowNumber(1)
+                    .setTripId("trip1")
+                    .setStopId("1001")
+                    .setStopSequence(1)
+                    .build();
+    private final GtfsStopTime insideBufferStopTime2 =
+            new GtfsStopTime.Builder()
+                    .setCsvRowNumber(2)
+                    .setTripId("trip1")
+                    .setStopId("1002")
+                    .setStopSequence(2)
+                    .build();
+    private final GtfsStopTime outsideBufferStopTime =
+            new GtfsStopTime.Builder()
+                    .setCsvRowNumber(3)
+                    .setTripId("trip1")
+                    .setStopId("1003")
+                    .setStopSequence(3)
+                    .build();
+
+    private final GtfsShape shape1 =
+            new GtfsShape.Builder()
+                    .setCsvRowNumber(1)
+                    .setShapeId("shape1")
+                    .setShapePtLat(28.05724310653972d)
+                    .setShapePtLon(-82.41350776611507d)
+                    .setShapePtSequence(1)
+                    .build();
+    private final GtfsShape shape2 =
+            new GtfsShape.Builder()
+                    .setCsvRowNumber(2)
+                    .setShapeId("shape1")
+                    .setShapePtLat(28.05746701492806d)
+                    .setShapePtLon(-82.41493135129478d)
+                    .setShapePtSequence(2)
+                    .build();
+    private final GtfsShape shape3 =
+            new GtfsShape.Builder()
+                    .setCsvRowNumber(3)
+                    .setShapeId("shape1")
+                    .setShapePtLat(28.05800068503469d)
+                    .setShapePtLon(-82.4159394137605d)
+                    .setShapePtSequence(3)
+                    .build();
+    private final GtfsShape shape4 =
+            new GtfsShape.Builder()
+                    .setCsvRowNumber(4)
+                    .setShapeId("shape1")
+                    .setShapePtLat(28.05808869825447d)
+                    .setShapePtLon(-82.41648754043338d)
+                    .setShapePtSequence(4)
+                    .build();
+    private final GtfsShape shape5 =
+            new GtfsShape.Builder()
+                    .setCsvRowNumber(5)
+                    .setShapeId("shape1")
+                    .setShapePtLat(28.05809979887893d)
+                    .setShapePtLon(-82.41773971025437d)
+                    .setShapePtSequence(5)
+                    .build();
+
+    private final GtfsTrip trip =
+            new GtfsTrip.Builder().setCsvRowNumber(1).setTripId("trip1").setShapeId("shape1").build();
 
     @Test
     public void stopWithinTripShapeShouldNotGenerateNotice() {
@@ -47,90 +137,28 @@ public class StopTooFarFromTripShapeValidatorTest {
 
         // Create stopTable:
         List<GtfsStop> stops = new ArrayList<>();
-        stops.add(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(1)
-                        .setStopId("1001")
-                        .setStopLat(28.05811731042478d)
-                        .setStopLon(-82.41616877502503d)
-                        .setLocationType(GtfsLocationType.STOP.getNumber())
-                        .build());
-        stops.add(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(2)
-                        .setStopId("1002")
-                        .setStopLat(28.05812364854794d)
-                        .setStopLon(-82.41617370439423d)
-                        .setLocationType(GtfsLocationType.STOP.getNumber())
-                        .build());
+        stops.add(insideBufferStop1);
+        stops.add(insideBufferStop2);
         validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
 
         // Create stopTimeTable:
         List<GtfsStopTime> stopTimes = new ArrayList<>();
-        stopTimes.add(
-                new GtfsStopTime.Builder()
-                        .setCsvRowNumber(1)
-                        .setTripId("trip1")
-                        .setStopId("1001")
-                        .setStopSequence(1)
-                        .build());
-        stopTimes.add(
-                new GtfsStopTime.Builder()
-                        .setCsvRowNumber(2)
-                        .setTripId("trip1")
-                        .setStopId("1002")
-                        .setStopSequence(2)
-                        .build());
+        stopTimes.add(insideBufferStopTime1);
+        stopTimes.add(insideBufferStopTime2);
         validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
 
         // Create shapeTable:
         List<GtfsShape> shapes = new ArrayList<>();
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(1)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05724310653972d)
-                        .setShapePtLon(-82.41350776611507d)
-                        .setShapePtSequence(1)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(2)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05746701492806d)
-                        .setShapePtLon(-82.41493135129478d)
-                        .setShapePtSequence(2)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(3)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05800068503469d)
-                        .setShapePtLon(-82.4159394137605d)
-                        .setShapePtSequence(3)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(4)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05808869825447d)
-                        .setShapePtLon(-82.41648754043338d)
-                        .setShapePtSequence(4)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(5)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05809979887893d)
-                        .setShapePtLon(-82.41773971025437d)
-                        .setShapePtSequence(5)
-                        .build());
+        shapes.add(shape1);
+        shapes.add(shape2);
+        shapes.add(shape3);
+        shapes.add(shape4);
+        shapes.add(shape5);
         validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
 
         // Create tripTable:
         List<GtfsTrip> trips = new ArrayList<>();
-        trips.add(
-                new GtfsTrip.Builder().setCsvRowNumber(1).setTripId("trip1").setShapeId("shape1").build());
+        trips.add(trip);
         validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
 
         validator.validate(noticeContainer);
@@ -146,106 +174,31 @@ public class StopTooFarFromTripShapeValidatorTest {
 
         // Create stopTable:
         List<GtfsStop> stops = new ArrayList<>();
-        stops.add(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(1)
-                        .setStopId("1001")
-                        .setStopLat(28.05811731042478d)
-                        .setStopLon(-82.41616877502503d)
-                        .setLocationType(GtfsLocationType.STOP.getNumber())
-                        .build());
-        stops.add(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(2)
-                        .setStopId("1002")
-                        .setStopLat(28.05812364854794d)
-                        .setStopLon(-82.41617370439423d)
-                        .setLocationType(GtfsLocationType.STOP.getNumber())
-                        .build());
-        // stopId "1003" is the location OUTSIDE buffer.
-        stops.add(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(3)
-                        .setStopId("1003")
-                        .setStopLat(28.05673053256373d)
-                        .setStopLon(-82.4170801432763d)
-                        .setLocationType(GtfsLocationType.STOP.getNumber())
-                        .build());
+        stops.add(insideBufferStop1);
+        stops.add(insideBufferStop2);
+        // The outside-buffer stop is added.
+        stops.add(outsideBufferStop);
         validator.stopTable = GtfsStopTableContainer.forEntities(stops, noticeContainer);
 
         // Create stopTimeTable:
         List<GtfsStopTime> stopTimes = new ArrayList<>();
-        stopTimes.add(
-                new GtfsStopTime.Builder()
-                        .setCsvRowNumber(1)
-                        .setTripId("trip1")
-                        .setStopId("1001")
-                        .setStopSequence(1)
-                        .build());
-        stopTimes.add(
-                new GtfsStopTime.Builder()
-                        .setCsvRowNumber(2)
-                        .setTripId("trip1")
-                        .setStopId("1002")
-                        .setStopSequence(2)
-                        .build());
-        stopTimes.add(
-                new GtfsStopTime.Builder()
-                        .setCsvRowNumber(3)
-                        .setTripId("trip1")
-                        .setStopId("1003")
-                        .setStopSequence(3)
-                        .build());
+        stopTimes.add(insideBufferStopTime1);
+        stopTimes.add(insideBufferStopTime2);
+        stopTimes.add(outsideBufferStopTime);
         validator.stopTimeTable = GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
 
         // Create shapeTable:
         List<GtfsShape> shapes = new ArrayList<>();
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(1)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05724310653972d)
-                        .setShapePtLon(-82.41350776611507d)
-                        .setShapePtSequence(1)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(2)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05746701492806d)
-                        .setShapePtLon(-82.41493135129478d)
-                        .setShapePtSequence(2)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(3)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05800068503469d)
-                        .setShapePtLon(-82.4159394137605d)
-                        .setShapePtSequence(3)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(4)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05808869825447d)
-                        .setShapePtLon(-82.41648754043338d)
-                        .setShapePtSequence(4)
-                        .build());
-        shapes.add(
-                new GtfsShape.Builder()
-                        .setCsvRowNumber(5)
-                        .setShapeId("shape1")
-                        .setShapePtLat(28.05809979887893d)
-                        .setShapePtLon(-82.41773971025437d)
-                        .setShapePtSequence(5)
-                        .build());
+        shapes.add(shape1);
+        shapes.add(shape2);
+        shapes.add(shape3);
+        shapes.add(shape4);
+        shapes.add(shape5);
         validator.shapeTable = GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
 
         // Create tripTable:
         List<GtfsTrip> trips = new ArrayList<>();
-        trips.add(
-                new GtfsTrip.Builder().setCsvRowNumber(1).setTripId("trip1").setShapeId("shape1").build());
+        trips.add(trip);
         validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
 
         validator.validate(noticeContainer);

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -158,7 +158,7 @@ public class StopTooFarFromTripShapeValidatorTest {
             noticeContainer);
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices()).containsExactly(
-            new StopTooFarFromTripShapeNotice("1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
+            new StopTooFarFromTripShapeNotice("1003", 3, 28.05673053256373d, -82.4170801432763d, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
         );
     }
 }

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -16,49 +16,76 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.ArrayList;
-import org.mobilitydata.gtfsvalidator.table.GtfsStop;
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsShape;
-import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
-import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
-
-import static com.google.common.truth.Truth.assertThat;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 @RunWith(JUnit4.class)
 public class StopTooFarFromTripShapeValidatorTest {
-
-    public static GtfsStop createStop(long csvRowNumber, String stopId, double stopLat, double stopLon, GtfsLocationType locationType) {
-        return new GtfsStop.Builder().setCsvRowNumber(csvRowNumber).setStopId(stopId).setStopLat(stopLat).setStopLon(stopLon).setLocationType(locationType.getNumber()).build();
+    public static GtfsStop createStop(long csvRowNumber, String stopId, double stopLat,
+            double stopLon, GtfsLocationType locationType) {
+        return new GtfsStop.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setStopId(stopId)
+            .setStopLat(stopLat)
+            .setStopLon(stopLon)
+            .setLocationType(locationType.getNumber())
+            .build();
     }
 
-    public static GtfsStopTime createStopTime(long csvRowNumber, String tripId, String stopId, int stopSequence) {
-        return new GtfsStopTime.Builder().setCsvRowNumber(csvRowNumber).setTripId(tripId).setStopId(stopId).setStopSequence(stopSequence).build();
+    public static GtfsStopTime createStopTime(
+            long csvRowNumber, String tripId, String stopId, int stopSequence) {
+        return new GtfsStopTime.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setTripId(tripId)
+            .setStopId(stopId)
+            .setStopSequence(stopSequence)
+            .build();
     }
 
-    public static GtfsShape createShape(long csvRowNumber, String shapeId, double shapePtLat, double shapePtLon, int shapePtSequence) {
-        return new GtfsShape.Builder().setCsvRowNumber(csvRowNumber).setShapeId(shapeId).setShapePtLat(shapePtLat).setShapePtLon(shapePtLon).setShapePtSequence(shapePtSequence).build();
+    public static GtfsShape createShape(long csvRowNumber, String shapeId, double shapePtLat,
+            double shapePtLon, int shapePtSequence) {
+        return new GtfsShape.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setShapeId(shapeId)
+            .setShapePtLat(shapePtLat)
+            .setShapePtLon(shapePtLon)
+            .setShapePtSequence(shapePtSequence)
+            .build();
     }
 
     public static GtfsTrip createTrip(long csvRowNumber, String tripId, String shapeId) {
-        return new GtfsTrip.Builder().setCsvRowNumber(csvRowNumber).setTripId(tripId).setShapeId(shapeId).build();
+        return new GtfsTrip.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setTripId(tripId)
+            .setShapeId(shapeId)
+            .build();
     }
 
-    private static GtfsStopTableContainer createStopTable(String[] stopIds, double[] stopLats, double[] stopLons, GtfsLocationType[] locationTypes, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(stopIds.length == stopLats.length, "stopIds.length must be equal to stopLats.length");
-        Preconditions.checkArgument(stopLats.length == stopLons.length, "stopLats.length must be equal to stopLons.length");
-        Preconditions.checkArgument(stopIds.length == locationTypes.length, "stopIds.length must be equal to locationTypes.length");
+    private static GtfsStopTableContainer createStopTable(String[] stopIds, double[] stopLats,
+            double[] stopLons, GtfsLocationType[] locationTypes, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(
+            stopIds.length == stopLats.length, "stopIds.length must be equal to stopLats.length");
+        Preconditions.checkArgument(
+            stopLats.length == stopLons.length, "stopLats.length must be equal to stopLons.length");
+        Preconditions.checkArgument(
+            stopIds.length == locationTypes.length, "stopIds.length must be equal to locationTypes.length");
         List<GtfsStop> stops = new ArrayList<>();
         for (int i = 0; i < stopIds.length; i++) {
             stops.add(createStop(stops.size() + 1, stopIds[i], stopLats[i], stopLons[i], locationTypes[i]));
@@ -66,9 +93,12 @@ public class StopTooFarFromTripShapeValidatorTest {
         return GtfsStopTableContainer.forEntities(stops, noticeContainer);
     }
 
-    private static GtfsStopTimeTableContainer createStopTimeTable(String[] tripIds, String[] stopIds, int[] stopSequences, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(tripIds.length == stopIds.length, "tripIds.length must be equal to stopIds.length");
-        Preconditions.checkArgument(stopIds.length == stopSequences.length, "stopIds.length must be equal to stopSequences.length");
+    private static GtfsStopTimeTableContainer createStopTimeTable(
+            String[] tripIds, String[] stopIds, int[] stopSequences, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(
+            tripIds.length == stopIds.length, "tripIds.length must be equal to stopIds.length");
+        Preconditions.checkArgument(
+            stopIds.length == stopSequences.length, "stopIds.length must be equal to stopSequences.length");
         List<GtfsStopTime> stopTimes = new ArrayList<>();
         for (int i = 0; i < stopIds.length; i++) {
             stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], stopIds[i], stopSequences[i]));
@@ -76,10 +106,14 @@ public class StopTooFarFromTripShapeValidatorTest {
         return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
     }
 
-    private static GtfsShapeTableContainer createShapeTable(String[] shapeIds, double[] shapePtLats, double[] shapePtLons, int[] shapePtSequences, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(shapeIds.length == shapePtLats.length, "shapeIds.length must be equal to shapePtLats.length");
-        Preconditions.checkArgument(shapePtLats.length == shapePtLons.length, "shapePtLats.length must be equal to shapePtLons.length");
-        Preconditions.checkArgument(shapeIds.length == shapePtSequences.length, "shapeIds.length must be equal to shapePtSequences.length");
+    private static GtfsShapeTableContainer createShapeTable(String[] shapeIds, double[] shapePtLats,
+            double[] shapePtLons, int[] shapePtSequences, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(
+            shapeIds.length == shapePtLats.length, "shapeIds.length must be equal to shapePtLats.length");
+        Preconditions.checkArgument(
+            shapePtLats.length == shapePtLons.length, "shapePtLats.length must be equal to shapePtLons.length");
+        Preconditions.checkArgument(
+            shapeIds.length == shapePtSequences.length, "shapeIds.length must be equal to shapePtSequences.length");
         List<GtfsShape> shapes = new ArrayList<>();
         for (int i = 0; i < shapePtLats.length; i++) {
             shapes.add(createShape(shapes.size() + 1, shapeIds[i], shapePtLats[i], shapePtLons[i], shapePtSequences[i]));
@@ -87,8 +121,10 @@ public class StopTooFarFromTripShapeValidatorTest {
         return GtfsShapeTableContainer.forEntities(shapes, noticeContainer);
     }
 
-    private static GtfsTripTableContainer createTripTable(String[] tripIds, String[] shapeIds, NoticeContainer noticeContainer) {
-        Preconditions.checkArgument(tripIds.length == shapeIds.length, "tripIds.length must be equal to shapeIds.length");
+    private static GtfsTripTableContainer createTripTable(
+            String[] tripIds, String[] shapeIds, NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(
+            tripIds.length == shapeIds.length, "tripIds.length must be equal to shapeIds.length");
         List<GtfsTrip> trips = new ArrayList<>();
         for (int i = 0; i < tripIds.length; i++) {
             trips.add(createTrip(trips.size() + 1, tripIds[i], shapeIds[i]));
@@ -98,64 +134,80 @@ public class StopTooFarFromTripShapeValidatorTest {
 
     @Test
     public void stopWithinTripShapeShouldNotGenerateNotice() {
-        // See map of trip shape and stops (in GeoJSON) at https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+        // See map of trip shape and stops (in GeoJSON) at
+        // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
         final NoticeContainer noticeContainer = new NoticeContainer();
         StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
-        validator.stopTable = createStopTable(
-            new String[]{"1001", "1002"},
-            new double[]{28.05811731042478d, 28.05812364854794d},
-            new double[]{-82.41616877502503d, -82.41617370439423d},
-            new GtfsLocationType[]{GtfsLocationType.STOP, GtfsLocationType.STOP},
-            noticeContainer);
-        validator.stopTimeTable = createStopTimeTable(
-            new String[]{"trip1", "trip1"},
-            new String[]{"1001", "1002"},
-            new int[]{1, 2},
-            noticeContainer);
-        validator.shapeTable = createShapeTable(
-            new String[]{"shape1", "shape1", "shape1", "shape1", "shape1"},
-            new double[]{28.05724310653972d, 28.05746701492806d, 28.05800068503469d, 28.05808869825447d, 28.05809979887893d},
-            new double[]{-82.41350776611507d, -82.41493135129478d, -82.4159394137605d, -82.41648754043338d, -82.41773971025437d},
-            new int[]{1, 2, 3, 4, 5},
-            noticeContainer);
-        validator.tripTable = createTripTable(
-            new String[]{"trip1"},
-            new String[]{"shape1"},
-            noticeContainer);
+        validator.stopTable = 
+            createStopTable(
+                new String[] {"1001", "1002"},
+                new double[] {28.05811731042478d, 28.05812364854794d},
+                new double[] {-82.41616877502503d, -82.41617370439423d},
+                new GtfsLocationType[] {GtfsLocationType.STOP, GtfsLocationType.STOP}, 
+                noticeContainer);
+        validator.stopTimeTable = 
+            createStopTimeTable(
+                new String[] {"trip1", "trip1"},
+                new String[] {"1001", "1002"},
+                new int[] {1, 2}, 
+                noticeContainer);
+        validator.shapeTable = 
+            createShapeTable(
+                new String[] {"shape1", "shape1", "shape1", "shape1", "shape1"},
+                new double[] {28.05724310653972d, 28.05746701492806d, 28.05800068503469d,
+                    28.05808869825447d, 28.05809979887893d},
+                new double[] {-82.41350776611507d, -82.41493135129478d, -82.4159394137605d,
+                    -82.41648754043338d, -82.41773971025437d},
+                new int[] {1, 2, 3, 4, 5}, 
+                noticeContainer);
+        validator.tripTable = 
+            createTripTable(
+                new String[] {"trip1"}, 
+                new String[] {"shape1"}, 
+                noticeContainer);
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices()).isEmpty();
     }
 
     @Test
     public void stopOutsideTripShapeShouldGenerateNotice() {
-        // See map of trip shape and stops (in GeoJSON) at https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+        // See map of trip shape and stops (in GeoJSON) at
+        // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
         final NoticeContainer noticeContainer = new NoticeContainer();
         StopTooFarFromTripShapeValidator validator = new StopTooFarFromTripShapeValidator();
-        validator.stopTable = createStopTable(
-            // stopId "1003" is the location OUTSIDE buffer.
-            new String[]{"1001", "1002", "1003"},
-            new double[]{28.05811731042478d, 28.05812364854794d, 28.05673053256373d},
-            new double[]{-82.41616877502503d, -82.41617370439423d, -82.4170801432763d},
-            new GtfsLocationType[]{GtfsLocationType.STOP, GtfsLocationType.STOP, GtfsLocationType.STOP},
-            noticeContainer);
-        validator.stopTimeTable = createStopTimeTable(
-            new String[]{"trip1", "trip1", "trip1"},
-            new String[]{"1001", "1002", "1003"},
-            new int[]{1, 2, 3},
-            noticeContainer);
-        validator.shapeTable = createShapeTable(
-            new String[]{"shape1", "shape1", "shape1", "shape1", "shape1"},
-            new double[]{28.05724310653972d, 28.05746701492806d, 28.05800068503469d, 28.05808869825447d, 28.05809979887893d},
-            new double[]{-82.41350776611507d, -82.41493135129478d, -82.4159394137605d, -82.41648754043338d, -82.41773971025437d},
-            new int[]{1, 2, 3, 4, 5},
-            noticeContainer);
-        validator.tripTable = createTripTable(
-            new String[]{"trip1"},
-            new String[]{"shape1"},
-            noticeContainer);
+        validator.stopTable = 
+            createStopTable(
+                // stopId "1003" is the location OUTSIDE buffer.
+                new String[] {"1001", "1002", "1003"},
+                new double[] {28.05811731042478d, 28.05812364854794d, 28.05673053256373d},
+                new double[] {-82.41616877502503d, -82.41617370439423d, -82.4170801432763d},
+                new GtfsLocationType[] {
+                    GtfsLocationType.STOP, GtfsLocationType.STOP, GtfsLocationType.STOP},
+                noticeContainer);
+        validator.stopTimeTable = 
+            createStopTimeTable(
+                new String[] {"trip1", "trip1", "trip1"},
+                new String[] {"1001", "1002", "1003"}, 
+                new int[] {1, 2, 3}, 
+                noticeContainer);
+        validator.shapeTable =
+            createShapeTable(
+                new String[] {"shape1", "shape1", "shape1", "shape1", "shape1"},
+                new double[] {28.05724310653972d, 28.05746701492806d, 28.05800068503469d,
+                    28.05808869825447d, 28.05809979887893d},
+                new double[] {-82.41350776611507d, -82.41493135129478d, -82.4159394137605d,
+                    -82.41648754043338d, -82.41773971025437d},
+                new int[] {1, 2, 3, 4, 5}, 
+                noticeContainer);
+        validator.tripTable =
+            createTripTable(
+                new String[] {"trip1"}, 
+                new String[] {"shape1"}, 
+                noticeContainer);
         validator.validate(noticeContainer);
-        assertThat(noticeContainer.getNotices()).containsExactly(
-            new StopTooFarFromTripShapeNotice("1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS)
-        );
+        assertThat(noticeContainer.getNotices())
+            .containsExactly(
+                new StopTooFarFromTripShapeNotice(
+                    "1003", 3, "trip1", "shape1", StopTooFarFromTripShapeValidator.TRIP_BUFFER_METERS));
     }
 }


### PR DESCRIPTION
Two tests are generated for the stopWithinTripShapeShouldNotGenerateNotice condition and stopOutsideTripShapeShouldGenerateNotice condition, respectively. Related helper methods to create GTFS objects (i.e. GtfsStop, GtfsStopTime, GtfsShape and GtfsTrip) and the corresponding tables are also included.
The tests passed successfully!

_p.s._ **4 space** (rather than 2 space) is kept for all validation rules, notices and tests files to keep it consistent with all existing (rules, notices and tests) files for the new validator. I have done **auto formatting** using [google-java-format](https://github.com/google/google-java-format) to make the formatting style consistent with other files in the new validator.

Please **only review the changes on "StopTooFarFromTripShapeValidatorTest" file**! All changes for "StopTooFarFromTripShape**Notice**" file are **covered by PR #9** . 