### PR TITLE
Add notice for meaningless trip

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MeaninglessTripNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MeaninglessTripNotice.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MeaninglessTripNotice extends Notice {
+  public MeaninglessTripNotice(String tripId, long csvRowNumber) {
+    super(
+        ImmutableMap.of(
+            "tripId", tripId,
+            "csvRowNumber", csvRowNumber));
+  }
+
+  @Override
+  public String getCode() {
+    return "meaningless_trip_with_no_more_than_one_stop";
+  }
+}


### PR DESCRIPTION
Meaningless trip notice for trips with no more than one stop.
The corresponding rule and tests will be added in the next PR.