### PR TITLE
Duplicate trip validator

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateTripNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateTripNotice.java
@@ -18,17 +18,10 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
-// Trip edge = first or last stop 
 public class DuplicateTripNotice extends Notice {
-  public DuplicateTripNotice(
-      String tripId, 
-      long csvRowNumberTrip1,
-      long csvRowNumberTrip2) {
-    super(
-        ImmutableMap.of(
-            "tripId", tripId,
-            "csvRowNumberTrip1", csvRowNumberTrip1,
-            "csvRowNumberTrip2", csvRowNumberTrip2));
+  public DuplicateTripNotice(String tripId, long csvRowNumberTrip1, long csvRowNumberTrip2) {
+    super(ImmutableMap.of("tripId", tripId, "csvRowNumberTrip1", csvRowNumberTrip1,
+        "csvRowNumberTrip2", csvRowNumberTrip2));
   }
 
   @Override

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateTripNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateTripNotice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+// Trip edge = first or last stop 
+public class DuplicateTripNotice extends Notice {
+  public DuplicateTripNotice(
+      String tripId, 
+      long csvRowNumberTrip1,
+      long csvRowNumberTrip2) {
+    super(
+        ImmutableMap.of(
+            "tripId", tripId,
+            "csvRowNumberTrip1", csvRowNumberTrip1,
+            "csvRowNumberTrip2", csvRowNumberTrip2));
+  }
+
+  @Override
+  public String getCode() {
+    return "duplicate_trip_found";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.Map;
+import java.util.HashMap;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateTripNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/**
+ * Validates that trip edges (first and last stops) for a trip define both arrival and departure
+ * stop times, for all trips.
+ *
+ * <p>Generated notice: {@link MissingTripEdgeStopTimeNotice} each time this is false.
+ */
+@GtfsValidator
+public class DuplicateTripValidator extends FileValidator {
+  @Inject GtfsTripTableContainer tripTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    Map<String, Long> tripIdAndCsv = new HashMap<>();
+    for (GtfsTrip trip : tripTable.getEntities()) {
+      final String tripId = trip.tripId();
+      if (tripIdAndCsv.containsKey(tripId)) {
+        noticeContainer.addNotice(new DuplicateTripNotice(tripId, trip.csvRowNumber(),tripIdAndCsv.get(tripId)));
+      }
+      tripIdAndCsv.put(tripId, trip.csvRowNumber());
+    }
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidator.java
@@ -16,8 +16,8 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateTripNotice;
@@ -26,10 +26,9 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 /**
- * Validates that trip edges (first and last stops) for a trip define both arrival and departure
- * stop times, for all trips.
+ * Validates there are no duplicate trips.
  *
- * <p>Generated notice: {@link MissingTripEdgeStopTimeNotice} each time this is false.
+ * <p>Generated notice: {@link DuplicateTripNotice} for each duplicate.
  */
 @GtfsValidator
 public class DuplicateTripValidator extends FileValidator {
@@ -41,7 +40,8 @@ public class DuplicateTripValidator extends FileValidator {
     for (GtfsTrip trip : tripTable.getEntities()) {
       final String tripId = trip.tripId();
       if (tripIdAndCsv.containsKey(tripId)) {
-        noticeContainer.addNotice(new DuplicateTripNotice(tripId, trip.csvRowNumber(),tripIdAndCsv.get(tripId)));
+        noticeContainer.addNotice(
+            new DuplicateTripNotice(tripId, trip.csvRowNumber(), tripIdAndCsv.get(tripId)));
       }
       tripIdAndCsv.put(tripId, trip.csvRowNumber());
     }

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateTripNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+
+@RunWith(JUnit4.class)
+public class DuplicateTripValidatorTest {
+  private final GtfsTrip trip1 =
+      new GtfsTrip.Builder().setCsvRowNumber(21).setTripId("trip1").build();
+  private final GtfsTrip trip2 =
+      new GtfsTrip.Builder().setCsvRowNumber(39).setTripId("trip1").build();
+  private final GtfsTrip trip3 =
+      new GtfsTrip.Builder().setCsvRowNumber(43).setTripId("trip3").build();
+
+  @Test
+  public void validShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateTripValidator validator = new DuplicateTripValidator();
+
+    // Create tripTable:
+    validator.tripTable = GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip3), noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateTripCreateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateTripValidator validator = new DuplicateTripValidator();
+
+    // Create tripTable:
+    validator.tripTable = GtfsTripTableContainer.forEntities(Arrays.asList(trip1,trip2), noticeContainer);
+
+    validator.validate(noticeContainer);
+    System.out.println(noticeContainer.exportJson());
+    assertThat(noticeContainer.getNotices())
+        .contains(new DuplicateTripNotice(
+            "trip1", /* csvRowNumberTrip1 = */ 39, /* csvRowNumberTrip2 = */ 21));
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
@@ -29,11 +29,11 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
 @RunWith(JUnit4.class)
 public class DuplicateTripValidatorTest {
-  private final GtfsTrip trip1 =
+  private final GtfsTrip trip1_line21 =
       new GtfsTrip.Builder().setCsvRowNumber(21).setTripId("trip1").build();
-  private final GtfsTrip trip2 =
+  private final GtfsTrip trip1_line39 =
       new GtfsTrip.Builder().setCsvRowNumber(39).setTripId("trip1").build();
-  private final GtfsTrip trip3 =
+  private final GtfsTrip trip3_line43 =
       new GtfsTrip.Builder().setCsvRowNumber(43).setTripId("trip3").build();
 
   @Test
@@ -43,7 +43,7 @@ public class DuplicateTripValidatorTest {
 
     // Create tripTable:
     validator.tripTable =
-        GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip3), noticeContainer);
+        GtfsTripTableContainer.forEntities(Arrays.asList(trip1_line21, trip3_line43), noticeContainer);
 
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices()).isEmpty();
@@ -56,7 +56,7 @@ public class DuplicateTripValidatorTest {
 
     // Create tripTable:
     validator.tripTable =
-        GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip2), noticeContainer);
+        GtfsTripTableContainer.forEntities(Arrays.asList(trip1_line21, trip1_line39), noticeContainer);
 
     validator.validate(noticeContainer);
     System.out.println(noticeContainer.exportJson());

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateTripValidatorTest.java
@@ -27,7 +27,6 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 
-
 @RunWith(JUnit4.class)
 public class DuplicateTripValidatorTest {
   private final GtfsTrip trip1 =
@@ -43,7 +42,8 @@ public class DuplicateTripValidatorTest {
     DuplicateTripValidator validator = new DuplicateTripValidator();
 
     // Create tripTable:
-    validator.tripTable = GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip3), noticeContainer);
+    validator.tripTable =
+        GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip3), noticeContainer);
 
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices()).isEmpty();
@@ -55,7 +55,8 @@ public class DuplicateTripValidatorTest {
     DuplicateTripValidator validator = new DuplicateTripValidator();
 
     // Create tripTable:
-    validator.tripTable = GtfsTripTableContainer.forEntities(Arrays.asList(trip1,trip2), noticeContainer);
+    validator.tripTable =
+        GtfsTripTableContainer.forEntities(Arrays.asList(trip1, trip2), noticeContainer);
 
     validator.validate(noticeContainer);
     System.out.println(noticeContainer.exportJson());


### PR DESCRIPTION
(Might not be useful to include into the validator because the duplicate_key notice already picks this up). 

I chose to use a map because I had to store the tripId and the corresponding csv row number. 

I then chose to use a HashMap because it is implemented as a hash table, and there is no ordering on keys or values.  This means that there is expected constant-time performance O(1) for operations like add(), and contains(). 

This is better than a TreeMap which has performance O(log(n)). And order is not important here so the red-black tree structure, (ordered by the key), which is not required. 

This means the space complexity is O(n) in relation to the number of trips, and time complexity O(n) because there is one iteration through the trip table.