### PR TITLE
Add "duplicate route long name and short name combination" rule

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateRouteLongNameShortNameCombinationNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateRouteLongNameShortNameCombinationNotice.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DuplicateRouteLongNameShortNameCombinationNotice extends Notice {
+  public DuplicateRouteLongNameShortNameCombinationNotice(
+      String comparedRouteId,
+      String comparedRouteLongName,
+      String comparedRouteShortName,
+      String routeId,
+      String routeLongName,
+      String routeShortName) {
+    super(
+        new ImmutableMap.Builder<String, Object>()
+            .put("comparedRouteId", comparedRouteId)
+            .put("comparedRouteLongName", comparedRouteLongName)
+            .put("comparedRouteShortName", comparedRouteShortName)
+            .put("routeId", routeId)
+            .put("routeLongName", routeLongName)
+            .put("routeShortName", routeShortName)
+            .build());
+  }
+
+  @Override
+  public String getCode() {
+    return "duplicate_route_long_name_short_name_combination";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteLongNameShortNameCombinationNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+
+/**
+ * Validates short or long names for a route are unique.
+ *
+ * <p>Generated notices:
+ *
+ * <ul>
+ *   <li>{@link DuplicateRouteLongNameShortNameCombinationNotice}
+ *   <li>{@link DuplicateRouteShortNameNotice}
+ *   <li>{@link DuplicateRouteLongNameNotice}
+ * </ul>
+ */
+@GtfsValidator
+public class RouteUniqueNamesValidator extends FileValidator {
+  @Inject GtfsRouteTableContainer routeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    final Map<String, GtfsRoute> routesByLongNameShortName = new HashMap<>();
+    for (GtfsRoute route : routeTable.getEntities()) {
+      String routeLongName = Optional.ofNullable(route.routeLongName()).orElse("");
+      String routeShortName = Optional.ofNullable(route.routeShortName()).orElse("");
+      if (routeLongName != "") {
+        // For DuplicateRouteLongNameNotice
+      }
+      if (routeShortName != "") {
+        // For DuplicateRouteShortNameNotice
+      }
+      // Checks uniqueness of combination of fields `route_long_name` and `route_short_name`
+      if (routesByLongNameShortName.containsKey(routeLongName + routeShortName)) {
+        GtfsRoute comparedRoute = routesByLongNameShortName.get(routeLongName + routeShortName);
+        noticeContainer.addNotice(
+            new DuplicateRouteLongNameShortNameCombinationNotice(
+                comparedRoute.routeId(),
+                Optional.ofNullable(comparedRoute.routeLongName()).orElse(""),
+                Optional.ofNullable(comparedRoute.routeShortName()).orElse(""),
+                route.routeId(),
+                routeLongName,
+                routeShortName));
+      } else {
+        routesByLongNameShortName.put(routeLongName + routeShortName, route);
+      }
+    }
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
@@ -32,9 +32,9 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
  * <p>Generated notices:
  *
  * <ul>
- *   <li>{@link DuplicateRouteLongNameShortNameCombinationNotice}
- *   <li>{@link DuplicateRouteShortNameNotice}
  *   <li>{@link DuplicateRouteLongNameNotice}
+ *   <li>{@link DuplicateRouteShortNameNotice}
+ *   <li>{@link DuplicateRouteLongNameShortNameCombinationNotice}
  * </ul>
  */
 @GtfsValidator
@@ -48,10 +48,10 @@ public class RouteUniqueNamesValidator extends FileValidator {
       String routeLongName = Optional.ofNullable(route.routeLongName()).orElse("");
       String routeShortName = Optional.ofNullable(route.routeShortName()).orElse("");
       if (routeLongName != "") {
-        // For DuplicateRouteLongNameNotice
+        // TODO: For DuplicateRouteLongNameNotice
       }
       if (routeShortName != "") {
-        // For DuplicateRouteShortNameNotice
+        // TODO: For DuplicateRouteShortNameNotice
       }
       // Checks uniqueness of combination of fields `route_long_name` and `route_short_name`
       if (routesByLongNameShortName.containsKey(routeLongName + routeShortName)) {

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,9 +76,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyLongName_abcd);
-    routes.add(routeOnlyShortName_abcd);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeOnlyShortName_abcd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -92,9 +92,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyLongName_alpha);
-    routes.add(routeOnlyShortName_abcd);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyLongName_alpha, routeOnlyShortName_abcd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -106,9 +105,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyLongName_abcd);
-    routes.add(routeOnlyLongName_alpha);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeOnlyLongName_alpha));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -120,9 +118,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyLongName_abcd);
-    routes.add(routeLongName_ab_ShortName_cd);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeLongName_ab_ShortName_cd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -137,9 +134,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyShortName_abcd);
-    routes.add(routeLongName_ab_ShortName_cd);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyShortName_abcd, routeLongName_ab_ShortName_cd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -159,9 +155,8 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeOnlyShortName_abcd);
-    routes.add(routeLongName_cd_ShortName_ab);
+    List<GtfsRoute> routes =
+        new ArrayList<>(Arrays.asList(routeOnlyShortName_abcd, routeLongName_cd_ShortName_ab));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -173,9 +168,9 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeLongName_ab_ShortName_cd);
-    routes.add(routeLongName_abc_ShortName_d);
+    List<GtfsRoute> routes =
+        new ArrayList<>(
+            Arrays.asList(routeLongName_ab_ShortName_cd, routeLongName_abc_ShortName_d));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);
@@ -195,9 +190,9 @@ public class RouteUniqueNamesValidatorTest {
     final NoticeContainer noticeContainer = new NoticeContainer();
     RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
 
-    List<GtfsRoute> routes = new ArrayList<>();
-    routes.add(routeLongName_ab_ShortName_cd);
-    routes.add(routeLongName_cd_ShortName_ab);
+    List<GtfsRoute> routes =
+        new ArrayList<>(
+            Arrays.asList(routeLongName_ab_ShortName_cd, routeLongName_cd_ShortName_ab));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
 
     validator.validate(noticeContainer);

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
@@ -84,7 +84,12 @@ public class RouteUniqueNamesValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(
             new DuplicateRouteLongNameShortNameCombinationNotice(
-                "routeOnlyLongName_abcd", "abcd", "", "routeOnlyShortName_abcd", "", "abcd"));
+                /* comparedRouteId= */ "routeOnlyLongName_abcd",
+                /* comparedRouteLongName= */ "abcd",
+                /* comparedRouteShortName= */ "",
+                /* routeId= */ "routeOnlyShortName_abcd",
+                /* routeLongName= */ "",
+                /* routeShortName= */ "abcd"));
   }
 
   @Test
@@ -126,7 +131,12 @@ public class RouteUniqueNamesValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(
             new DuplicateRouteLongNameShortNameCombinationNotice(
-                "routeOnlyLongName_abcd", "abcd", "", "routeLongName_ab_ShortName_cd", "ab", "cd"));
+                /* comparedRouteId= */ "routeOnlyLongName_abcd",
+                /* comparedRouteLongName= */ "abcd",
+                /* comparedRouteShortName= */ "",
+                /* routeId= */ "routeLongName_ab_ShortName_cd",
+                /* routeLongName= */ "ab",
+                /* routeShortName= */ "cd"));
   }
 
   @Test
@@ -142,12 +152,12 @@ public class RouteUniqueNamesValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(
             new DuplicateRouteLongNameShortNameCombinationNotice(
-                "routeOnlyShortName_abcd",
-                "",
-                "abcd",
-                "routeLongName_ab_ShortName_cd",
-                "ab",
-                "cd"));
+                /* comparedRouteId= */ "routeOnlyShortName_abcd",
+                /* comparedRouteLongName= */ "",
+                /* comparedRouteShortName= */ "abcd",
+                /* routeId= */ "routeLongName_ab_ShortName_cd",
+                /* routeLongName= */ "ab",
+                /* routeShortName= */ "cd"));
   }
 
   @Test
@@ -177,12 +187,12 @@ public class RouteUniqueNamesValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(
             new DuplicateRouteLongNameShortNameCombinationNotice(
-                "routeLongName_ab_ShortName_cd",
-                "ab",
-                "cd",
-                "routeLongName_abc_ShortName_d",
-                "abc",
-                "d"));
+                /* comparedRouteId= */ "routeLongName_ab_ShortName_cd",
+                /* comparedRouteLongName= */ "ab",
+                /* comparedRouteShortName= */ "cd",
+                /* routeId= */ "routeLongName_abc_ShortName_d",
+                /* routeLongName= */ "abc",
+                /* routeShortName= */ "d"));
   }
 
   @Test

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
@@ -31,6 +31,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 
 @RunWith(JUnit4.class)
 public class RouteUniqueNamesValidatorTest {
+  private RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
   private final GtfsRoute routeOnlyLongName_abcd =
       new GtfsRoute.Builder()
           .setCsvRowNumber(1)
@@ -74,8 +75,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyLongNameEqualsAnotherRouteOnlyShortName() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeOnlyShortName_abcd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -95,8 +94,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyLongNameDifferentFromAnotherRouteOnlyShortName() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyLongName_alpha, routeOnlyShortName_abcd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -108,8 +105,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyLongNameDifferentFromAnotherRouteOnlyLongName() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeOnlyLongName_alpha));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -121,8 +116,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyLongNameEqualsAnotherRouteBothLongShortNames() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyLongName_abcd, routeLongName_ab_ShortName_cd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -142,8 +135,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyShortNameEqualsAnotherRouteBothLongShortNames() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyShortName_abcd, routeLongName_ab_ShortName_cd));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -163,8 +154,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeOnlyShortNameDifferentFromAnotherRouteBothLongShortNames() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(Arrays.asList(routeOnlyShortName_abcd, routeLongName_cd_ShortName_ab));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -176,8 +165,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeBothLongShortNamesEqualsAnotherRouteBothLongShortNames() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(
             Arrays.asList(routeLongName_ab_ShortName_cd, routeLongName_abc_ShortName_d));
@@ -198,8 +185,6 @@ public class RouteUniqueNamesValidatorTest {
   @Test
   public void routeBothLongShortNamesDifferentFromAnotherRouteBothLongShortNames() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
-
     List<GtfsRoute> routes =
         new ArrayList<>(
             Arrays.asList(routeLongName_ab_ShortName_cd, routeLongName_cd_ShortName_ab));

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteLongNameShortNameCombinationNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+
+@RunWith(JUnit4.class)
+public class RouteUniqueNamesValidatorTest {
+  private final GtfsRoute routeOnlyLongName_abcd =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(1)
+          .setRouteId("routeOnlyLongName_abcd")
+          .setRouteLongName("abcd")
+          .build();
+  private final GtfsRoute routeOnlyLongName_alpha =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(2)
+          .setRouteId("routeOnlyLongName_alpha")
+          .setRouteLongName("alpha")
+          .build();
+  private final GtfsRoute routeOnlyShortName_abcd =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(3)
+          .setRouteId("routeOnlyShortName_abcd")
+          .setRouteShortName("abcd")
+          .build();
+  private final GtfsRoute routeLongName_ab_ShortName_cd =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(4)
+          .setRouteId("routeLongName_ab_ShortName_cd")
+          .setRouteLongName("ab")
+          .setRouteShortName("cd")
+          .build();
+  private final GtfsRoute routeLongName_cd_ShortName_ab =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(5)
+          .setRouteId("routeLongName_cd_ShortName_ab")
+          .setRouteLongName("cd")
+          .setRouteShortName("ab")
+          .build();
+  private final GtfsRoute routeLongName_abc_ShortName_d =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(6)
+          .setRouteId("routeLongName_abc_ShortName_d")
+          .setRouteLongName("abc")
+          .setRouteShortName("d")
+          .build();
+
+  @Test
+  public void routeOnlyLongNameEqualsAnotherRouteOnlyShortName() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyLongName_abcd);
+    routes.add(routeOnlyShortName_abcd);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new DuplicateRouteLongNameShortNameCombinationNotice(
+                "routeOnlyLongName_abcd", "abcd", "", "routeOnlyShortName_abcd", "", "abcd"));
+  }
+
+  @Test
+  public void routeOnlyLongNameDifferentFromAnotherRouteOnlyShortName() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyLongName_alpha);
+    routes.add(routeOnlyShortName_abcd);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void routeOnlyLongNameDifferentFromAnotherRouteOnlyLongName() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyLongName_abcd);
+    routes.add(routeOnlyLongName_alpha);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void routeOnlyLongNameEqualsAnotherRouteBothLongShortNames() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyLongName_abcd);
+    routes.add(routeLongName_ab_ShortName_cd);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new DuplicateRouteLongNameShortNameCombinationNotice(
+                "routeOnlyLongName_abcd", "abcd", "", "routeLongName_ab_ShortName_cd", "ab", "cd"));
+  }
+
+  @Test
+  public void routeOnlyShortNameEqualsAnotherRouteBothLongShortNames() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyShortName_abcd);
+    routes.add(routeLongName_ab_ShortName_cd);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new DuplicateRouteLongNameShortNameCombinationNotice(
+                "routeOnlyShortName_abcd",
+                "",
+                "abcd",
+                "routeLongName_ab_ShortName_cd",
+                "ab",
+                "cd"));
+  }
+
+  @Test
+  public void routeOnlyShortNameDifferentFromAnotherRouteBothLongShortNames() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeOnlyShortName_abcd);
+    routes.add(routeLongName_cd_ShortName_ab);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void routeBothLongShortNamesEqualsAnotherRouteBothLongShortNames() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeLongName_ab_ShortName_cd);
+    routes.add(routeLongName_abc_ShortName_d);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new DuplicateRouteLongNameShortNameCombinationNotice(
+                "routeLongName_ab_ShortName_cd",
+                "ab",
+                "cd",
+                "routeLongName_abc_ShortName_d",
+                "abc",
+                "d"));
+  }
+
+  @Test
+  public void routeBothLongShortNamesDifferentFromAnotherRouteBothLongShortNames() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    RouteUniqueNamesValidator validator = new RouteUniqueNamesValidator();
+
+    List<GtfsRoute> routes = new ArrayList<>();
+    routes.add(routeLongName_ab_ShortName_cd);
+    routes.add(routeLongName_cd_ShortName_ab);
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+}


### PR DESCRIPTION
This PR adds a validator rule with its corresponding notice and tests for no route with duplicate route long name and short name combination.
Only "DuplicateRouteLongNameShortNameCombination" check is finished in the "RouteUniqueNamesValidator". "DuplicateRouteShortName" and "DuplicateRouteLongName" checks for the same agency will be added later - space is left using comments.

In "RouteUniqueNamesValidator" file, I choose to use HashMap to record checked routes - the combination name (i.e. routeLongName + routeShortName) is used as key, the corresponding value is the route. I use HashMap to find the corresponding checked route which has the same combination name as the current checking route with smaller time complexity O(1). We need to store the route as value because we want to output the detailed information of the route if the notice is produced. Storing the route directly, rather than storing all necessary information around the route in the Map can save space.