### PR TITLE
add buildSoy dependency onto appengine

### DIFF
--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 // Always run unit tests
 appengineDeploy.dependsOn test
 appengineStage.dependsOn test
+appengineRun.dependsOn buildSoy
 
 appengine {  // App Engine tasks configuration
   deploy {   // deploy configuration


### PR DESCRIPTION
Add buildSoy onto appengine in build.gradle so won't need to manually run `gradle :webapp:buildSoy`