### PR TITLE
Stops Too Close Validator

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopsTooCloseNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopsTooCloseNotice.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+// [warning]
+public class StopsTooCloseNotice extends Notice {
+  public StopsTooCloseNotice(String stopId1, long csvRowNumberStop1, String stopId2,
+      long csvRowNumberStop2, double tripBufferMeters) {
+    super(ImmutableMap.of("stopId1", stopId1, "csvRowNumberStop1", csvRowNumberStop1, "stopId2",
+        stopId2, "csvRowNumberStop2", csvRowNumberStop2, "tripBufferMeters", tripBufferMeters));
+  }
+
+  @Override
+  public String getCode() {
+    return "stops_too_close_to_each_other_warning";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
@@ -40,18 +40,16 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 @GtfsValidator
 public class StopsTooCloseValidator extends FileValidator {
   private static final int KILOMETER_TO_METER_CONVERSION_FACTOR = 1000;
-  /**
-   * At equator 1 degree = 110.567 kilometers.
-   * 0.00005 degrees = (110.567km * 1000) * 0.00005 = 5.52835 m
-   * At poles 1 degree = 111.699 kilometers.
-   * 0.00005 degrees = (111.699km * 1000) * 0.00005 = 5.58495 m
-   *
-   * So the latitude buffer is 0.00005 degrees to check stops within at least 5.52835 m
-   */
-  private static final double LAT_BUFFER = 0.00005;
 
   // If stops are closer than 5m based on distance calculated, generate a notice
   static final int DIST_BUFFER_METERS = 5;
+
+  /**
+   * Convert DIST_BUFFER_METERS to degrees of latitude. Converts a distance in the units of the
+   * radius to degrees (360 degrees are in a circle). Assumming spherical earth model
+   */
+  private static final double LAT_BUFFER = DistanceUtils.dist2Degrees(DIST_BUFFER_METERS,
+      DistanceUtils.EARTH_EQUATORIAL_RADIUS_KM* KILOMETER_TO_METER_CONVERSION_FACTOR);
 
   @Inject GtfsStopTableContainer stopTable;
 

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.locationtech.spatial4j.context.SpatialContext.GEO;
+
+import com.google.common.collect.Multimaps;
+import java.lang.Double;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.locationtech.spatial4j.distance.DistanceCalculator;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.ShapeFactory;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopsTooCloseNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+/**
+ * Validates that two stops are not too close to each other.
+ *
+ * <p>Generated notice: {@link StopsTooCloseNotice}.
+ */
+@GtfsValidator
+public class StopsTooCloseValidator extends FileValidator {
+  static final int KILOMETER_TO_METER_CONVERSION_FACTOR = 1000;
+  /**
+  * At equator 1 degree = 110.567 kilometers.
+  * 0.00005 degrees = (110.567km * 1000) * 0.00005 = 5.52835 m
+  * At poles 1 degree = 111.699 kilometers.
+  * 0.00005 degrees = (111.699km * 1000) * 0.00005 = 5.58495 m
+  *
+  * So the latitude buffer is 0.00005 degrees to check stops within at least 5.52835 m 
+  */
+  private static final double LAT_BUFFER = 0.00005;
+
+  // If stops are closer than 5m based on distance calculated, generate a notice
+  static final int DIST_BUFFER_METERS = 5;
+
+  @Inject GtfsStopTableContainer stopTable;
+
+  private static ShapeFactory getShapeFactory() {
+    return GEO.getShapeFactory();
+  }
+
+  private static DistanceCalculator getDistanceCalculator() {
+    return GEO.getDistCalc();
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    List<GtfsStop> allStops = stopTable.getEntities();
+    Collections.sort(
+        allStops, (stop1, stop2) -> { return Double.compare(stop1.stopLat(), stop2.stopLat()); });
+
+    // Set up to calculate distance
+    final ShapeFactory shapeFactory = getShapeFactory();
+    final DistanceCalculator distanceCalculator = getDistanceCalculator();
+
+    for (int i = 0; i < allStops.size(); i++) {
+      GtfsStop stop1 = allStops.get(i);
+      Point pointStop1 = shapeFactory.pointXY(stop1.stopLon(), stop1.stopLat());
+
+      for (int j = i + 1; j < allStops.size(); j++) {
+        GtfsStop stop2 = allStops.get(j);
+        if (stop1.stopLat() - stop2.stopLat() < LAT_BUFFER) {
+          Point pointStop2 = shapeFactory.pointXY(stop2.stopLon(), stop2.stopLat());
+
+          int distBetweenStopsMeters =
+              (int) (DistanceUtils.DEG_TO_KM * distanceCalculator.distance(pointStop1, pointStop2)
+                  * KILOMETER_TO_METER_CONVERSION_FACTOR);
+
+          if (distBetweenStopsMeters < DIST_BUFFER_METERS) {
+            noticeContainer.addNotice(new StopsTooCloseNotice(stop1.stopId(), stop1.csvRowNumber(),
+                stop2.stopId(), stop2.csvRowNumber(), DIST_BUFFER_METERS));
+          }
+          // Otherwise stop and start checking the next point
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
@@ -49,7 +49,7 @@ public class StopsTooCloseValidator extends FileValidator {
    * radius to degrees (360 degrees are in a circle). Assumming spherical earth model
    */
   private static final double LAT_BUFFER = DistanceUtils.dist2Degrees(DIST_BUFFER_METERS,
-      DistanceUtils.EARTH_EQUATORIAL_RADIUS_KM* KILOMETER_TO_METER_CONVERSION_FACTOR);
+      DistanceUtils.EARTH_EQUATORIAL_RADIUS_KM * KILOMETER_TO_METER_CONVERSION_FACTOR);
 
   @Inject GtfsStopTableContainer stopTable;
 

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
@@ -42,7 +42,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
  */
 @GtfsValidator
 public class StopsTooCloseValidator extends FileValidator {
-  static final int KILOMETER_TO_METER_CONVERSION_FACTOR = 1000;
+  private static final int KILOMETER_TO_METER_CONVERSION_FACTOR = 1000;
   /**
   * At equator 1 degree = 110.567 kilometers.
   * 0.00005 degrees = (110.567km * 1000) * 0.00005 = 5.52835 m

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidator.java
@@ -18,9 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.locationtech.spatial4j.context.SpatialContext.GEO;
 
-import com.google.common.collect.Multimaps;
 import java.lang.Double;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.locationtech.spatial4j.distance.DistanceCalculator;
@@ -31,7 +29,6 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StopsTooCloseNotice;
-import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 
@@ -44,13 +41,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 public class StopsTooCloseValidator extends FileValidator {
   private static final int KILOMETER_TO_METER_CONVERSION_FACTOR = 1000;
   /**
-  * At equator 1 degree = 110.567 kilometers.
-  * 0.00005 degrees = (110.567km * 1000) * 0.00005 = 5.52835 m
-  * At poles 1 degree = 111.699 kilometers.
-  * 0.00005 degrees = (111.699km * 1000) * 0.00005 = 5.58495 m
-  *
-  * So the latitude buffer is 0.00005 degrees to check stops within at least 5.52835 m 
-  */
+   * At equator 1 degree = 110.567 kilometers.
+   * 0.00005 degrees = (110.567km * 1000) * 0.00005 = 5.52835 m
+   * At poles 1 degree = 111.699 kilometers.
+   * 0.00005 degrees = (111.699km * 1000) * 0.00005 = 5.58495 m
+   *
+   * So the latitude buffer is 0.00005 degrees to check stops within at least 5.52835 m
+   */
   private static final double LAT_BUFFER = 0.00005;
 
   // If stops are closer than 5m based on distance calculated, generate a notice
@@ -82,12 +79,12 @@ public class StopsTooCloseValidator extends FileValidator {
 
       for (int j = i + 1; j < allStops.size(); j++) {
         GtfsStop stop2 = allStops.get(j);
-        if (stop1.stopLat() - stop2.stopLat() < LAT_BUFFER) {
+        if (stop2.stopLat() - stop1.stopLat() < LAT_BUFFER) {
           Point pointStop2 = shapeFactory.pointXY(stop2.stopLon(), stop2.stopLat());
 
-          int distBetweenStopsMeters =
-              (int) (DistanceUtils.DEG_TO_KM * distanceCalculator.distance(pointStop1, pointStop2)
-                  * KILOMETER_TO_METER_CONVERSION_FACTOR);
+          double distBetweenStopsMeters = DistanceUtils.DEG_TO_KM
+              * distanceCalculator.distance(pointStop1, pointStop2)
+              * KILOMETER_TO_METER_CONVERSION_FACTOR;
 
           if (distBetweenStopsMeters < DIST_BUFFER_METERS) {
             noticeContainer.addNotice(new StopsTooCloseNotice(stop1.stopId(), stop1.csvRowNumber(),

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
@@ -48,31 +48,26 @@ public class StopsTooCloseValidatorTest {
                                      .setStopLon(-82.416d)
                                      .build();
 
+  private final NoticeContainer noticeContainer = new NoticeContainer();
+  private final StopsTooCloseValidator validator = new StopsTooCloseValidator();
+
   @Test
   public void stopsSpacedOutShouldNotGenerateNotice() {
-    final NoticeContainer noticeContainer = new NoticeContainer();
-    StopsTooCloseValidator validator = new StopsTooCloseValidator();
-
     // Create stopTable:
     validator.stopTable =
         GtfsStopTableContainer.forEntities(Arrays.asList(stop1, stop2), noticeContainer);
 
     validator.validate(noticeContainer);
-    System.out.println(noticeContainer.exportJson());
     assertThat(noticeContainer.getNotices()).isEmpty();
   }
 
   @Test
   public void stopsTooCloseGenerateNotice() {
-    final NoticeContainer noticeContainer = new NoticeContainer();
-    StopsTooCloseValidator validator = new StopsTooCloseValidator();
-
     // Create stopTable:
     validator.stopTable = GtfsStopTableContainer.forEntities(
         Arrays.asList(stop1, stop2, stop3), noticeContainer);
 
     validator.validate(noticeContainer);
-    System.out.println(noticeContainer.exportJson());
     assertThat(noticeContainer.getNotices())
         .containsExactly(
             new StopsTooCloseNotice(/** stopId1 = */ "1001", /** csvRowNumberStop1 = */ 1,

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
@@ -64,8 +64,8 @@ public class StopsTooCloseValidatorTest {
   @Test
   public void stopsTooCloseGenerateNotice() {
     // Create stopTable:
-    validator.stopTable = GtfsStopTableContainer.forEntities(
-        Arrays.asList(stop1, stop2, stop3), noticeContainer);
+    validator.stopTable =
+        GtfsStopTableContainer.forEntities(Arrays.asList(stop1, stop2, stop3), noticeContainer);
 
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopsTooCloseValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopsTooCloseNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+@RunWith(JUnit4.class)
+public class StopsTooCloseValidatorTest {
+  private final GtfsStop stop1 = new GtfsStop.Builder()
+                                     .setCsvRowNumber(1)
+                                     .setStopId("1001")
+                                     .setStopLat(28.0581d)
+                                     .setStopLon(-82.416d)
+                                     .build();
+  private final GtfsStop stop2 = new GtfsStop.Builder()
+                                     .setCsvRowNumber(2)
+                                     .setStopId("1002")
+                                     .setStopLat(28.0582d)
+                                     .setStopLon(-82.416d)
+                                     .build();
+  private final GtfsStop stop3 = new GtfsStop.Builder()
+                                     .setCsvRowNumber(3)
+                                     .setStopId("1003")
+                                     .setStopLat(28.05811d)
+                                     .setStopLon(-82.416d)
+                                     .build();
+
+  @Test
+  public void stopsSpacedOutShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    StopsTooCloseValidator validator = new StopsTooCloseValidator();
+
+    // Create stopTable:
+    validator.stopTable =
+        GtfsStopTableContainer.forEntities(Arrays.asList(stop1, stop2), noticeContainer);
+
+    validator.validate(noticeContainer);
+    System.out.println(noticeContainer.exportJson());
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void stopsTooCloseGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    StopsTooCloseValidator validator = new StopsTooCloseValidator();
+
+    // Create stopTable:
+    validator.stopTable = GtfsStopTableContainer.forEntities(
+        Arrays.asList(stop1, stop2, stop3), noticeContainer);
+
+    validator.validate(noticeContainer);
+    System.out.println(noticeContainer.exportJson());
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new StopsTooCloseNotice(/** stopId1 = */ "1001", /** csvRowNumberStop1 = */ 1,
+                /** stopId2 = */ "1003", /** csvRowNumberStop2 = */ 3,
+                StopsTooCloseValidator.DIST_BUFFER_METERS));
+  }
+}


### PR DESCRIPTION
This rule checks that all stops in stops.txt are sufficiently distanced from each other. If they are too close it generates a warning. A naive solution to this problem would be to compare each stop to every other stop O(n^2). There are more complex algorithms that use a spatial index (a data structure that allows for accessing a spatial object efficiently, which average search O(log n) but worst case is O(n)). However, the added space complexity and time spent to create the spatial index is not necessary for this problem where there is a finite number of stops. 

This solution is a slight improvement on the naive solution. It sorts the stops by latitude first and then compares, which is O(n log n) using merge sort. If the stops are greater than 0.00005 degrees away, approximately 5m away based on the latitude, the loop breaks and we move onto the next stop. If all the stops are at the same location this has the worst case running time of O(n^2) but in practice it should improve the running time considerably. Resulting in a running time between O(n) and O(n^2).