### PR TITLE
Rule validates that trips in the same block have consistent route types

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithInconsistentRouteTypesNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithInconsistentRouteTypesNotice.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
+
+public class BlockTripsWithInconsistentRouteTypesNotice extends Notice {
+  public BlockTripsWithInconsistentRouteTypesNotice(
+      String blockId,
+      long tripCsvRowNumberA,
+      String tripIdA,
+      GtfsRouteType routeTypeA,
+      String routeIdA,
+      long tripCsvRowNumberB,
+      String tripIdB,
+      GtfsRouteType routeTypeB,
+      String routeIdB) {
+    super(
+        new ImmutableMap.Builder<String, Object>()
+            .put("blockId", blockId)
+            .put("tripCsvRowNumberA", tripCsvRowNumberA)
+            .put("tripIdA", tripIdA)
+            .put("routeTypeA", routeTypeA)
+            .put("routeIdA", routeIdA)
+            .put("tripCsvRowNumberB", tripCsvRowNumberB)
+            .put("tripIdB", tripIdB)
+            .put("routeTypeB", routeTypeB)
+            .put("routeIdB", routeIdB)
+            .build());
+  }
+
+  @Override
+  public String getCode() {
+    return "block_trips_with_inconsistent_route_types";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.auto.value.AutoValue;
+import java.util.HashMap;
+import java.util.Map;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.BlockTripsWithInconsistentRouteTypesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/** Uses AutoValue to record necessary trip information. */
+@AutoValue
+abstract class TripRouteTypeIdentifier {
+  static TripRouteTypeIdentifier create(
+      GtfsRouteType routeType, String tripId, long tripCsvRowNumber, String routeId) {
+    return new AutoValue_TripRouteTypeIdentifier(routeType, tripId, tripCsvRowNumber, routeId);
+  }
+
+  abstract GtfsRouteType routeType();
+
+  abstract String tripId();
+
+  abstract long tripCsvRowNumber();
+
+  abstract String routeId();
+}
+
+/**
+ * Validates trips in the same block have consistent route types.
+ *
+ * <p>Generated notices: {@link BlockTripsWithInconsistentRouteTypesNotice}.
+ */
+@GtfsValidator
+public class BlockTripsWithInconsistentRouteTypesValidator extends FileValidator {
+  @Inject GtfsTripTableContainer tripTable;
+  @Inject GtfsRouteTableContainer routeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    // Store trip information that includes route type and other fields which need to be added to
+    // the notice
+    final Map<String, TripRouteTypeIdentifier> blockTripInfoStorage = new HashMap<>();
+    for (GtfsTrip trip : tripTable.getEntities()) {
+      // Referring to route table, find the route type corresponding to the routeId of a specific
+      // trip
+      final GtfsRouteType routeType = routeTable.byRouteId(trip.routeId()).routeType();
+      // If the block has appeared, check whether the corresponding route type is the same as record
+      if (blockTripInfoStorage.containsKey(trip.blockId())) {
+        final TripRouteTypeIdentifier recordedBlockTripInfo =
+            blockTripInfoStorage.get(trip.blockId());
+        // If the route types for the trips in the same block are different, a notice is generated
+        if (recordedBlockTripInfo.routeType().getNumber() != routeType.getNumber()) {
+          noticeContainer.addNotice(
+              new BlockTripsWithInconsistentRouteTypesNotice(
+                  /* blockId= */ trip.blockId(),
+                  /* tripCsvRowNumberA= */ recordedBlockTripInfo.tripCsvRowNumber(),
+                  /* tripIdA= */ recordedBlockTripInfo.tripId(),
+                  /* routeTypeA= */ recordedBlockTripInfo.routeType(),
+                  /* routeIdA= */ recordedBlockTripInfo.routeId(),
+                  /* tripCsvRowNumberB= */ trip.csvRowNumber(),
+                  /* tripIdB= */ trip.tripId(),
+                  /* routeTypeB= */ routeType,
+                  /* routeIdB= */ trip.routeId()));
+        }
+      } else {
+        // If the block has never appeared, combine the necessary trip information as a
+        // TripRouteTypeIdentifier autovalue and put it as the value of the HashMap with blockId of
+        // the trip as key
+        blockTripInfoStorage.put(
+            trip.blockId(),
+            TripRouteTypeIdentifier.create(
+                routeType, trip.tripId(), trip.csvRowNumber(), trip.routeId()));
+      }
+    }
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidatorTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.BlockTripsWithInconsistentRouteTypesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+@RunWith(JUnit4.class)
+public class BlockTripsWithInconsistentRouteTypesValidatorTest {
+  private BlockTripsWithInconsistentRouteTypesValidator validator =
+      new BlockTripsWithInconsistentRouteTypesValidator();
+  private final GtfsTrip trip11 =
+      new GtfsTrip.Builder()
+          .setCsvRowNumber(1)
+          .setTripId("trip11")
+          .setRouteId("R1")
+          .setBlockId("BlockApple")
+          .build();
+  private final GtfsTrip trip111 =
+      new GtfsTrip.Builder()
+          .setCsvRowNumber(2)
+          .setTripId("trip111")
+          .setRouteId("R2")
+          .setBlockId("BlockApple")
+          .build();
+  private final GtfsTrip trip1111 =
+      new GtfsTrip.Builder()
+          .setCsvRowNumber(3)
+          .setTripId("trip1111")
+          .setRouteId("R3")
+          .setBlockId("BlockBanana")
+          .build();
+  private final GtfsTrip trip22 =
+      new GtfsTrip.Builder()
+          .setCsvRowNumber(4)
+          .setTripId("trip22")
+          .setRouteId("R4")
+          .setBlockId("BlockApple")
+          .build();
+  private final GtfsTrip trip222 =
+      new GtfsTrip.Builder()
+          .setCsvRowNumber(5)
+          .setTripId("trip222")
+          .setRouteId("R5")
+          .setBlockId("BlockBanana")
+          .build();
+  private final GtfsRoute route1 =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(1)
+          .setRouteId("R1")
+          .setRouteType(GtfsRouteType.BUS.getNumber())
+          .build();
+  private final GtfsRoute route2 =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(2)
+          .setRouteId("R2")
+          .setRouteType(GtfsRouteType.RAIL.getNumber())
+          .build();
+  private final GtfsRoute route3 =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(3)
+          .setRouteId("R3")
+          .setRouteType(GtfsRouteType.FERRY.getNumber())
+          .build();
+  private final GtfsRoute route4 =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(4)
+          .setRouteId("R4")
+          .setRouteType(GtfsRouteType.BUS.getNumber())
+          .build();
+  private final GtfsRoute route5 =
+      new GtfsRoute.Builder()
+          .setCsvRowNumber(5)
+          .setRouteId("R5")
+          .setRouteType(GtfsRouteType.BUS.getNumber())
+          .build();
+
+  @Test
+  public void sameBlockTripsWithDifferentRouteTypesShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip111));
+    validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route2));
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new BlockTripsWithInconsistentRouteTypesNotice(
+                /* blockId= */ "BlockApple",
+                /* tripCsvRowNumberA= */ 1,
+                /* tripIdA= */ "trip11",
+                /* routeTypeA= */ GtfsRouteType.BUS,
+                /* routeIdA= */ "R1",
+                /* tripCsvRowNumberB= */ 2,
+                /* tripIdB= */ "trip111",
+                /* routeTypeB= */ GtfsRouteType.RAIL,
+                /* routeIdB= */ "R2"));
+  }
+
+  @Test
+  public void differentBlockTripsWithDifferentRouteTypesShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip1111));
+    validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route3));
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void differentBlockTripsWithSameRouteTypesShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip222));
+    validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route5));
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void sameBlockTripsWithSameRouteTypesShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip22));
+    validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route4));
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void blockTripsCombination() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTrip> trips =
+        new ArrayList<>(Arrays.asList(trip11, trip111, trip1111, trip22, trip222));
+    validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route2, route3, route4, route5));
+    validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(
+            new BlockTripsWithInconsistentRouteTypesNotice(
+                /* blockId= */ "BlockApple",
+                /* tripCsvRowNumberA= */ 1,
+                /* tripIdA= */ "trip11",
+                /* routeTypeA= */ GtfsRouteType.BUS,
+                /* routeIdA= */ "R1",
+                /* tripCsvRowNumberB= */ 2,
+                /* tripIdB= */ "trip111",
+                /* routeTypeB= */ GtfsRouteType.RAIL,
+                /* routeIdB= */ "R2"),
+            new BlockTripsWithInconsistentRouteTypesNotice(
+                /* blockId= */ "BlockBanana",
+                /* tripCsvRowNumberA= */ 3,
+                /* tripIdA= */ "trip1111",
+                /* routeTypeA= */ GtfsRouteType.FERRY,
+                /* routeIdA= */ "R3",
+                /* tripCsvRowNumberB= */ 5,
+                /* tripIdB= */ "trip222",
+                /* routeTypeB= */ GtfsRouteType.BUS,
+                /* routeIdB= */ "R5"));
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithInconsistentRouteTypesValidatorTest.java
@@ -36,35 +36,35 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   private BlockTripsWithInconsistentRouteTypesValidator validator =
       new BlockTripsWithInconsistentRouteTypesValidator();
-  private final GtfsTrip trip11 =
+  private final GtfsTrip trip_bus_block_apple_1 =
       new GtfsTrip.Builder()
           .setCsvRowNumber(1)
           .setTripId("trip11")
           .setRouteId("R1")
           .setBlockId("BlockApple")
           .build();
-  private final GtfsTrip trip111 =
+  private final GtfsTrip trip_rail_block_apple =
       new GtfsTrip.Builder()
           .setCsvRowNumber(2)
           .setTripId("trip111")
           .setRouteId("R2")
           .setBlockId("BlockApple")
           .build();
-  private final GtfsTrip trip1111 =
+  private final GtfsTrip trip_ferry_block_banana =
       new GtfsTrip.Builder()
           .setCsvRowNumber(3)
           .setTripId("trip1111")
           .setRouteId("R3")
           .setBlockId("BlockBanana")
           .build();
-  private final GtfsTrip trip22 =
+  private final GtfsTrip trip_bus_block_apple_2 =
       new GtfsTrip.Builder()
           .setCsvRowNumber(4)
           .setTripId("trip22")
           .setRouteId("R4")
           .setBlockId("BlockApple")
           .build();
-  private final GtfsTrip trip222 =
+  private final GtfsTrip trip_bus_block_banana =
       new GtfsTrip.Builder()
           .setCsvRowNumber(5)
           .setTripId("trip222")
@@ -105,7 +105,8 @@ public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   @Test
   public void sameBlockTripsWithDifferentRouteTypesShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip111));
+    List<GtfsTrip> trips =
+        new ArrayList<>(Arrays.asList(trip_bus_block_apple_1, trip_rail_block_apple));
     validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
     List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route2));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -127,7 +128,8 @@ public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   @Test
   public void differentBlockTripsWithDifferentRouteTypesShouldNotGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip1111));
+    List<GtfsTrip> trips =
+        new ArrayList<>(Arrays.asList(trip_bus_block_apple_1, trip_ferry_block_banana));
     validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
     List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route3));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -138,7 +140,8 @@ public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   @Test
   public void differentBlockTripsWithSameRouteTypesShouldNotGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip222));
+    List<GtfsTrip> trips =
+        new ArrayList<>(Arrays.asList(trip_bus_block_apple_1, trip_bus_block_banana));
     validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
     List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route5));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -149,7 +152,8 @@ public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   @Test
   public void sameBlockTripsWithSameRouteTypesShouldNotGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTrip> trips = new ArrayList<>(Arrays.asList(trip11, trip22));
+    List<GtfsTrip> trips =
+        new ArrayList<>(Arrays.asList(trip_bus_block_apple_1, trip_bus_block_apple_2));
     validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
     List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route4));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);
@@ -161,7 +165,13 @@ public class BlockTripsWithInconsistentRouteTypesValidatorTest {
   public void blockTripsCombination() {
     final NoticeContainer noticeContainer = new NoticeContainer();
     List<GtfsTrip> trips =
-        new ArrayList<>(Arrays.asList(trip11, trip111, trip1111, trip22, trip222));
+        new ArrayList<>(
+            Arrays.asList(
+                trip_bus_block_apple_1,
+                trip_rail_block_apple,
+                trip_ferry_block_banana,
+                trip_bus_block_apple_2,
+                trip_bus_block_banana));
     validator.tripTable = GtfsTripTableContainer.forEntities(trips, noticeContainer);
     List<GtfsRoute> routes = new ArrayList<>(Arrays.asList(route1, route2, route3, route4, route5));
     validator.routeTable = GtfsRouteTableContainer.forEntities(routes, noticeContainer);


### PR DESCRIPTION
HashMap is used to store a block_id (as key) and its corresponding trip information (an AutoValue as value). The AutoValue includes trip's route type and other necessary information for notice generation. For a specific block_id, only the information of a trip that appears first for the block_id will be recorded. All other trips with the same block_id will be compared with the initially recorded trip. Their route types should be the same as the route type should not be changed inside a block; otherwise, a notice is generated.
HashMap is used to find the specific block_id more quickly in O(1) (as key). 
AutoValue is used to store other necessary trip fields as the value of HashMap, to extract specific field faster and easily. Compared to get an element in a List, the AutoValue field name is more straight-forward than the List index. In addition, by using AutoValue, you can know the specific AutoValue length rather than facing the unfixed length of extendable List.