### PR TITLE
Template for wrong parent location type (with tests)

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -47,3 +47,8 @@ function invalid_row_length(params) {
   const template = goog.soy.renderAsElement(validator.templates.invalidRowLength, params);
   document.getElementById("error").appendChild(template);
 }
+
+function wrong_parent_location_type(params) {
+  const template = goog.soy.renderAsElement(validator.templates.wrongParentLocationType, params);
+  document.getElementById("error").appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -64,3 +64,43 @@
   <p>Please set the row length as specified by the CSV header!</p>
   <br><br>
 {/template}
+
+
+/**
+ * Renders a basic explanation of the validation notice.
+ * @param notices : List<[stopId : string, csvRowNumber : number, locationType: number, parentStation : string, parentCsvRowNumber: number, parentLocationType: number, expectedLocationType: number]>
+ */
+{template .wrongParentLocationType}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Wrong parent location type!</p>
+  <p>Description: Incorrect type of the parent location (e.g. a parent for a stop or an entrance must be a station).</p>
+  <p><b>{$numNotices}</b> Wrong parent location type found in:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Stop Id</th>
+        <th>CSV Row Number</th>
+        <th>Location Type</th>
+        <th>Parent Station</th>
+        <th>Parent CSV Row Number</th>
+        <th>Parent Location Type</th>
+        <th>Expected Location Type</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.stopId}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.locationType}</td>
+          <td>{$notice.parentStation}</td>
+          <td>{$notice.parentCsvRowNumber}</td>
+          <td>{$notice.parentLocationType}</td>
+          <td>{$notice.expectedLocationType}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please fix the parent location type corresponding to the stop location type!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -78,7 +78,7 @@
   <table>
     <thead>
       <tr>
-        <th>Stop Id</th>
+        <th>Stop ID</th>
         <th>CSV Row Number</th>
         <th>Location Type</th>
         <th>Parent Station</th>

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -101,6 +101,6 @@
       {/foreach}
     </tbody>
   </table>
-  <p>Please fix the parent location type corresponding to the stop location type!</p>
+  <p>Please fix the parent location type(s) corresponding to the stop location type(s)!</p>
   <br><br>
 {/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -104,7 +104,7 @@ describe('Output', function() {
 <p><b>1</b> Wrong parent location type found in:</p>\
 <table>\
 <thead>\
-<tr><th>Stop Id</th><th>CSV Row Number</th><th>Location Type</th><th>Parent Station</th><th>Parent CSV Row Number</th><th>Parent Location Type</th><th>Expected Location Type</th></tr>\
+<tr><th>Stop ID</th><th>CSV Row Number</th><th>Location Type</th><th>Parent Station</th><th>Parent CSV Row Number</th><th>Parent Location Type</th><th>Expected Location Type</th></tr>\
 </thead>\
 <tbody>\
 <tr><td>stop101</td><td>4</td><td>0</td><td>station1001</td><td>7</td><td>2</td><td>1</td></tr>\

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -110,7 +110,7 @@ describe('Output', function() {
 <tr><td>stop101</td><td>4</td><td>0</td><td>station1001</td><td>7</td><td>2</td><td>1</td></tr>\
 </tbody>\
 </table>\
-<p>Please fix the parent location type corresponding to the stop location type!</p><br><br></div>'
+<p>Please fix the parent location type(s) corresponding to the stop location type(s)!</p><br><br></div>'
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
   

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -81,6 +81,38 @@ describe('Output', function() {
 <p>Please set the row length as specified by the CSV header!</p><br><br></div>"
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
+
+  it('should issue wrong parent location type error', function() {
+    const params = {
+      code: "wrong_parent_location_type",
+      totalNotices: 1,
+      notices: [
+        {
+          stopId: "stop101",
+          csvRowNumber: 4,
+          locationType: 0,
+          parentStation: "station1001",
+          parentCsvRowNumber: 7,
+          parentLocationType: 2,
+          expectedLocationType: 1
+        }
+      ]
+    };
+    wrong_parent_location_type(params);
+    const output ='<div><p class=\"error"\>Error - Wrong parent location type!</p>\
+<p>Description: Incorrect type of the parent location (e.g. a parent for a stop or an entrance must be a station).</p>\
+<p><b>1</b> Wrong parent location type found in:</p>\
+<table>\
+<thead>\
+<tr><th>Stop Id</th><th>CSV Row Number</th><th>Location Type</th><th>Parent Station</th><th>Parent CSV Row Number</th><th>Parent Location Type</th><th>Expected Location Type</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>stop101</td><td>4</td><td>0</td><td>station1001</td><td>7</td><td>2</td><td>1</td></tr>\
+</tbody>\
+</table>\
+<p>Please fix the parent location type corresponding to the stop location type!</p><br><br></div>'
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
   
   it('should call the correct functions', function() {
     const params = JSON.stringify({


### PR DESCRIPTION
Looks like:
<img width="553" alt="Screen Shot 2021-02-10 at 2 31 23 pm" src="https://user-images.githubusercontent.com/41321808/107460700-b75ffc00-6bac-11eb-8c9f-1c4fca03afd2.png">

Auto formatting is done in PR #40 . Because it includes reformatting for previous template's structure, I created another PR for that.