### PR TITLE
CalendarHasNoActiveDays rule implemented

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/CalendarHasNoActiveDaysNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/CalendarHasNoActiveDaysNotice.java
@@ -20,18 +20,10 @@ import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarService;
 
 public class CalendarHasNoActiveDaysNotice extends Notice {
-  public CalendarHasNoActiveDaysNotice(String serviceId, GtfsCalendarService monday,
-      GtfsCalendarService tuesday, GtfsCalendarService wednesday, GtfsCalendarService thursday,
-      GtfsCalendarService friday, GtfsCalendarService saturday, GtfsCalendarService sunday) {
+  public CalendarHasNoActiveDaysNotice(String serviceId, long calendarCsvRowNumber) {
     super(new ImmutableMap.Builder<String, Object>()
               .put("serviceId", serviceId)
-              .put("monday", monday)
-              .put("tuesday", tuesday)
-              .put("wednesday", wednesday)
-              .put("thursday", thursday)
-              .put("friday", friday)
-              .put("saturday", saturday)
-              .put("sunday", sunday)
+              .put("calendarCsvRowNumber", calendarCsvRowNumber)
               .build());
   }
 

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/CalendarHasNoActiveDaysNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/CalendarHasNoActiveDaysNotice.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarService;
+
+public class CalendarHasNoActiveDaysNotice extends Notice {
+  public CalendarHasNoActiveDaysNotice(String serviceId, GtfsCalendarService monday,
+      GtfsCalendarService tuesday, GtfsCalendarService wednesday, GtfsCalendarService thursday,
+      GtfsCalendarService friday, GtfsCalendarService saturday, GtfsCalendarService sunday) {
+    super(new ImmutableMap.Builder<String, Object>()
+              .put("serviceId", serviceId)
+              .put("monday", monday)
+              .put("tuesday", tuesday)
+              .put("wednesday", wednesday)
+              .put("thursday", thursday)
+              .put("friday", friday)
+              .put("saturday", saturday)
+              .put("sunday", sunday)
+              .build());
+  }
+
+  @Override
+  public String getCode() {
+    return "calendar_has_no_active_days";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
@@ -44,13 +44,7 @@ public class CalendarHasNoActiveDaysValidator extends FileValidator {
           < 1) {
         noticeContainer.addNotice(new CalendarHasNoActiveDaysNotice(
             /* serviceId= */ calendar.serviceId(),
-            /* monday= */ calendar.monday(),
-            /* tuesday= */ calendar.tuesday(),
-            /* wednesday= */ calendar.wednesday(),
-            /* thursday= */ calendar.thursday(),
-            /* friday= */ calendar.friday(),
-            /* saturday= */ calendar.saturday(),
-            /* sunday= */ calendar.sunday()));
+            /* calendarCsvRowNumber= */ calendar.csvRowNumber()));
       }
     }
   }

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
@@ -30,6 +30,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
  */
 @GtfsValidator
 public class CalendarHasNoActiveDaysValidator extends FileValidator {
+  private final static int NOT_AVAILBLE = 0;
+
   @Inject GtfsCalendarTableContainer calendarTable;
 
   @Override
@@ -37,11 +39,13 @@ public class CalendarHasNoActiveDaysValidator extends FileValidator {
     // Loop through calendar and add up enum values for each day. If value is less than 1, then no
     // days are active.
     for (GtfsCalendar calendar : calendarTable.getEntities()) {
-      if ((calendar.monday().getNumber() + calendar.tuesday().getNumber()
-              + calendar.wednesday().getNumber() + calendar.thursday().getNumber()
-              + calendar.friday().getNumber() + calendar.saturday().getNumber()
-              + calendar.sunday().getNumber())
-          < 1) {
+      if (calendar.monday().getNumber() == NOT_AVAILBLE
+          && calendar.tuesday().getNumber() == NOT_AVAILBLE
+          && calendar.wednesday().getNumber() == NOT_AVAILBLE
+          && calendar.thursday().getNumber() == NOT_AVAILBLE
+          && calendar.friday().getNumber() == NOT_AVAILBLE
+          && calendar.saturday().getNumber() == NOT_AVAILBLE
+          && calendar.sunday().getNumber() == NOT_AVAILBLE) {
         noticeContainer.addNotice(new CalendarHasNoActiveDaysNotice(
             /* serviceId= */ calendar.serviceId(),
             /* calendarCsvRowNumber= */ calendar.csvRowNumber()));

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
@@ -21,6 +21,7 @@ import org.mobilitydata.gtfsvalidator.annotation.Inject;
 import org.mobilitydata.gtfsvalidator.notice.CalendarHasNoActiveDaysNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarService;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
 
 /**
@@ -30,7 +31,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
  */
 @GtfsValidator
 public class CalendarHasNoActiveDaysValidator extends FileValidator {
-  private final static int NOT_AVAILBLE = 0;
+  private final static GtfsCalendarService NOT_AVAILABLE = GtfsCalendarService.NOT_AVAILABLE;
 
   @Inject GtfsCalendarTableContainer calendarTable;
 
@@ -39,13 +40,10 @@ public class CalendarHasNoActiveDaysValidator extends FileValidator {
     // Loop through calendar and add up enum values for each day. If value is less than 1, then no
     // days are active.
     for (GtfsCalendar calendar : calendarTable.getEntities()) {
-      if (calendar.monday().getNumber() == NOT_AVAILBLE
-          && calendar.tuesday().getNumber() == NOT_AVAILBLE
-          && calendar.wednesday().getNumber() == NOT_AVAILBLE
-          && calendar.thursday().getNumber() == NOT_AVAILBLE
-          && calendar.friday().getNumber() == NOT_AVAILBLE
-          && calendar.saturday().getNumber() == NOT_AVAILBLE
-          && calendar.sunday().getNumber() == NOT_AVAILBLE) {
+      if (calendar.monday() == NOT_AVAILABLE && calendar.tuesday() == NOT_AVAILABLE
+          && calendar.wednesday() == NOT_AVAILABLE && calendar.thursday() == NOT_AVAILABLE
+          && calendar.friday() == NOT_AVAILABLE && calendar.saturday() == NOT_AVAILABLE
+          && calendar.sunday() == NOT_AVAILABLE) {
         noticeContainer.addNotice(new CalendarHasNoActiveDaysNotice(
             /* serviceId= */ calendar.serviceId(),
             /* calendarCsvRowNumber= */ calendar.csvRowNumber()));

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.CalendarHasNoActiveDaysNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+
+/**
+ * Validates days in calendar.txt has at least one active (available) day.
+ *
+ * <p>Generated notices: {@link CalendarHasNoActiveDaysNotice}.
+ */
+@GtfsValidator
+public class CalendarHasNoActiveDaysValidator extends FileValidator {
+  @Inject GtfsCalendarTableContainer calendarTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    // Loop through calendar and add up enum values for each day. If value is less than 1, then no
+    // days are active.
+    for (GtfsCalendar calendar : calendarTable.getEntities()) {
+      if ((calendar.monday().getNumber() + calendar.tuesday().getNumber()
+              + calendar.wednesday().getNumber() + calendar.thursday().getNumber()
+              + calendar.friday().getNumber() + calendar.saturday().getNumber()
+              + calendar.sunday().getNumber())
+          < 1) {
+        noticeContainer.addNotice(new CalendarHasNoActiveDaysNotice(
+            /* serviceId= */ calendar.serviceId(),
+            /* monday= */ calendar.monday(),
+            /* tuesday= */ calendar.tuesday(),
+            /* wednesday= */ calendar.wednesday(),
+            /* thursday= */ calendar.thursday(),
+            /* friday= */ calendar.friday(),
+            /* saturday= */ calendar.saturday(),
+            /* sunday= */ calendar.sunday()));
+      }
+    }
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidatorTest.java
@@ -37,6 +37,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
   private final GtfsCalendar all_active_calendar =
       new GtfsCalendar.Builder()
           .setServiceId("service1")
+          .setCsvRowNumber(1)
           .setMonday(GtfsCalendarService.AVAILABLE.getNumber())
           .setTuesday(GtfsCalendarService.AVAILABLE.getNumber())
           .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
@@ -49,6 +50,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
   private final GtfsCalendar no_active_calendar =
       new GtfsCalendar.Builder()
           .setServiceId("service2")
+          .setCsvRowNumber(2)
           .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
           .setTuesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
           .setWednesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
@@ -61,6 +63,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
   private final GtfsCalendar one_active_calendar =
       new GtfsCalendar.Builder()
           .setServiceId("service_3")
+          .setCsvRowNumber(3)
           .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
           .setTuesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
           .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
@@ -73,6 +76,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
   private final GtfsCalendar more_active_calendar =
       new GtfsCalendar.Builder()
           .setServiceId("service_4")
+          .setCsvRowNumber(4)
           .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
           .setTuesday(GtfsCalendarService.AVAILABLE.getNumber())
           .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
@@ -108,13 +112,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(new CalendarHasNoActiveDaysNotice(
             /* serviceId= */ "service2",
-            /* monday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* tuesday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* wednesday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* thursday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* friday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* saturday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* sunday= */ GtfsCalendarService.NOT_AVAILABLE));
+            /* calendarCsvRowNumber= */ 2));
   }
 
   @Test
@@ -127,13 +125,7 @@ public class CalendarHasNoActiveDaysValidatorTest {
     assertThat(noticeContainer.getNotices())
         .containsExactly(new CalendarHasNoActiveDaysNotice(
             /* serviceId= */ "service2",
-            /* monday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* tuesday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* wednesday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* thursday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* friday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* saturday= */ GtfsCalendarService.NOT_AVAILABLE,
-            /* sunday= */ GtfsCalendarService.NOT_AVAILABLE));
+            /* calendarCsvRowNumber= */ 2));
   }
 
   @Test

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarHasNoActiveDaysValidatorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.CalendarHasNoActiveDaysNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarService;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+
+@RunWith(JUnit4.class)
+public class CalendarHasNoActiveDaysValidatorTest {
+  private CalendarHasNoActiveDaysValidator validator = new CalendarHasNoActiveDaysValidator();
+
+  private final GtfsCalendar all_active_calendar =
+      new GtfsCalendar.Builder()
+          .setServiceId("service1")
+          .setMonday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setTuesday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setThursday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setFriday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setSaturday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setSunday(GtfsCalendarService.AVAILABLE.getNumber())
+          .build();
+
+  private final GtfsCalendar no_active_calendar =
+      new GtfsCalendar.Builder()
+          .setServiceId("service2")
+          .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setTuesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setWednesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setThursday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setFriday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setSaturday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setSunday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .build();
+
+  private final GtfsCalendar one_active_calendar =
+      new GtfsCalendar.Builder()
+          .setServiceId("service_3")
+          .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setTuesday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setThursday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setFriday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setSaturday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setSunday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .build();
+
+  private final GtfsCalendar more_active_calendar =
+      new GtfsCalendar.Builder()
+          .setServiceId("service_4")
+          .setMonday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setTuesday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setWednesday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setThursday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setFriday(GtfsCalendarService.AVAILABLE.getNumber())
+          .setSaturday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .setSunday(GtfsCalendarService.NOT_AVAILABLE.getNumber())
+          .build();
+
+  @Test
+  public void allActiveDaysShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsCalendar> days = new ArrayList<>(Arrays.asList(all_active_calendar));
+    validator.calendarTable = GtfsCalendarTableContainer.forEntities(days, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void oneActiveDayShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsCalendar> days = new ArrayList<>(Arrays.asList(one_active_calendar));
+    validator.calendarTable = GtfsCalendarTableContainer.forEntities(days, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+  @Test
+  public void noActiveDaysShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsCalendar> days = new ArrayList<>(Arrays.asList(no_active_calendar));
+    validator.calendarTable = GtfsCalendarTableContainer.forEntities(days, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(new CalendarHasNoActiveDaysNotice(
+            /* serviceId= */ "service2",
+            /* monday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* tuesday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* wednesday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* thursday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* friday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* saturday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* sunday= */ GtfsCalendarService.NOT_AVAILABLE));
+  }
+
+  @Test
+  public void activeAndNoActiveDaysShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsCalendar> days =
+        new ArrayList<>(Arrays.asList(no_active_calendar, more_active_calendar));
+    validator.calendarTable = GtfsCalendarTableContainer.forEntities(days, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(new CalendarHasNoActiveDaysNotice(
+            /* serviceId= */ "service2",
+            /* monday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* tuesday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* wednesday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* thursday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* friday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* saturday= */ GtfsCalendarService.NOT_AVAILABLE,
+            /* sunday= */ GtfsCalendarService.NOT_AVAILABLE));
+  }
+
+  @Test
+  public void multipleActiveDaysShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsCalendar> days =
+        new ArrayList<>(Arrays.asList(one_active_calendar, more_active_calendar));
+    validator.calendarTable = GtfsCalendarTableContainer.forEntities(days, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+}


### PR DESCRIPTION
Rule to check that the calendar has at least one active (available) day. Used a simple for loop and if statement to implement the rule. Loops through all the calendars in the given ArrayList of GtfsCalendar and checks whether the sum of the enum values from monday->sunday is less than 1. If it is less than 1, then all days are unavailable and a notice should be called. 