### PR TITLE
Add template for Route unique names notice

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteUniqueNamesNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteUniqueNamesNotice.java
@@ -37,7 +37,7 @@ public class RouteUniqueNamesNotice extends Notice {
             .put("comparedRouteCsvRowNumber", comparedRouteCsvRowNumber)
             .put("routeLongName", routeLongName)
             .put("routeShortName", routeShortName)
-            .put("routeType", routeType)
+            .put("routeType", routeType.toString())
             .put("agencyId", agencyId)
             .build());
   }

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteUniqueNamesNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteUniqueNamesNotice.java
@@ -27,7 +27,7 @@ public class RouteUniqueNamesNotice extends Notice {
       long comparedRouteCsvRowNumber,
       String routeLongName,
       String routeShortName,
-      GtfsRouteType routeType,
+      String routeType,
       String agencyId) {
     super(
         new ImmutableMap.Builder<String, Object>()
@@ -37,7 +37,7 @@ public class RouteUniqueNamesNotice extends Notice {
             .put("comparedRouteCsvRowNumber", comparedRouteCsvRowNumber)
             .put("routeLongName", routeLongName)
             .put("routeShortName", routeShortName)
-            .put("routeType", routeType.toString())
+            .put("routeType", routeType)
             .put("agencyId", agencyId)
             .build());
   }

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
@@ -81,6 +81,7 @@ public class RouteUniqueNamesValidator extends FileValidator {
       // If the combination of names, type and agency ID for a route appeared before, a notice is
       // generated
       if (testedRoutes.containsKey(routeIdentifier)) {
+        // Generate a notice
         noticeContainer.addNotice(
             new RouteUniqueNamesNotice(
                 route.routeId(),
@@ -89,7 +90,8 @@ public class RouteUniqueNamesValidator extends FileValidator {
                 /* comparedRouteCsvRowNumber= */ testedRoutes.get(routeIdentifier).csvRowNumber(),
                 routeIdentifier.longName(),
                 routeIdentifier.shortName(),
-                routeIdentifier.routeType(),
+                // Get routeType as a string without "GtfsRouteType."
+                routeIdentifier.routeType().toString().split("GtfsRouteType.")[0],
                 routeIdentifier.agencyId()));
       } else {
         // Add necessary route information for notice to the storage with the routeIdentifier as key

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidator.java
@@ -91,7 +91,7 @@ public class RouteUniqueNamesValidator extends FileValidator {
                 routeIdentifier.longName(),
                 routeIdentifier.shortName(),
                 // Get routeType as a string without "GtfsRouteType."
-                routeIdentifier.routeType().toString().split("GtfsRouteType.")[0],
+                routeIdentifier.routeType().toString().replace("GtfsRouteType.",""),
                 routeIdentifier.agencyId()));
       } else {
         // Add necessary route information for notice to the storage with the routeIdentifier as key

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteUniqueNamesValidatorTest.java
@@ -148,7 +148,7 @@ public class RouteUniqueNamesValidatorTest {
                 /* comparedRouteCsvRowNumber= */ 5,
                 /* routeLongName= */ "abcd-long-name",
                 /* routeShortName= */ "abcd",
-                /* routeType= */ GtfsRouteType.SUBWAY,
+                /* routeType= */ "SUBWAY",
                 /* agencyId= */ "agency1"));
   }
 
@@ -167,7 +167,7 @@ public class RouteUniqueNamesValidatorTest {
                 /* comparedRouteCsvRowNumber= */ 2,
                 /* routeLongName= */ "",
                 /* routeShortName= */ "abcd",
-                /* routeType= */ GtfsRouteType.BUS,
+                /* routeType= */ "BUS",
                 /* agencyId= */ ""));
   }
 
@@ -188,7 +188,7 @@ public class RouteUniqueNamesValidatorTest {
                 /* comparedRouteCsvRowNumber= */ 5,
                 /* routeLongName= */ "abcd-long-name",
                 /* routeShortName= */ "abcd",
-                /* routeType= */ GtfsRouteType.SUBWAY,
+                /* routeType= */ "SUBWAY",
                 /* agencyId= */ "agency1"),
             new RouteUniqueNamesNotice(
                 /* routeId= */ "routeH",
@@ -197,7 +197,7 @@ public class RouteUniqueNamesValidatorTest {
                 /* comparedRouteCsvRowNumber= */ 2,
                 /* routeLongName= */ "",
                 /* routeShortName= */ "abcd",
-                /* routeType= */ GtfsRouteType.BUS,
+                /* routeType= */ "BUS",
                 /* agencyId= */ ""));
   }
 }

--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -131,3 +131,9 @@ function stop_time_with_arrival_before_previous_departure_time(params) {
       params);
   document.getElementById('error').appendChild(template);
 }
+
+function route_unique_names(params) {
+  const template =
+      goog.soy.renderAsElement(validator.templates.routeUniqueNames, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -137,3 +137,9 @@ function route_unique_names(params) {
       goog.soy.renderAsElement(validator.templates.routeUniqueNames, params);
   document.getElementById('error').appendChild(template);
 }
+
+function station_with_parent_station(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.stationWithParentStation, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -522,6 +522,43 @@
   <br><br>
 {/template}
 
-
-
-
+/**
+ * Renders a basic explanation of the route unique names notice.
+ * @param notices : List<[routeId : string, routeCsvRowNumber : number, comparedRouteId : string, comparedRouteCsvRowNumber: number, routeLongName : string, routeShortName : string, routeType : string, agencyId : string]>
+ */
+{template .routeUniqueNames}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Route without unique names!</p>
+  <p>Description: The combination of long name, short name, route type and agency ID for a route is not unique.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Route ID</th>
+        <th>Route CSV Row Number</th>
+        <th>Compared Route ID</th>
+        <th>Compared Route CSV Row Number</th>
+        <th>Route Long Name</th>
+        <th>Route Short Name</th>
+        <th>Route Type</th>
+        <th>Agency ID</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.routeId}</td>
+          <td>{$notice.routeCsvRowNumber}</td>
+          <td>{$notice.comparedRouteId}</td>
+          <td>{$notice.comparedRouteCsvRowNumber}</td>
+          <td>{$notice.routeLongName}</td>
+          <td>{$notice.routeShortName}</td>
+          <td>{$notice.routeType}</td>
+          <td>{$notice.agencyId}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please change the long name or short name of the route to make it unique!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -562,3 +562,34 @@
   <p>Please change the long name or short name of the route to make it unique!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the station with parent station notice.
+ * @param notices : List<[stopId : string, csvRowNumber : number, parentStation : string]>
+ */
+{template .stationWithParentStation}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Station with parent station!</p>
+  <p>Description: A station has parent_station field set.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Station ID</th>
+        <th>CSV Row Number</th>
+        <th>Parent Station</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.stopId}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.parentStation}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please delete the parent station of the station!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -560,6 +560,32 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for station with parent station notice */
+  it('should issue station with parent station error', function() {
+    const params = {
+      code: 'station_with_parent_station',
+      totalNotices: 1,
+      notices:
+          [{stopId: 'StationB', csvRowNumber: 8, parentStation: 'StationW'}]
+    };
+    station_with_parent_station(params);
+    const output =
+        '<div><p class="error">Error - Station with parent station!</p>\
+<p>Description: A station has parent_station field set.</p>\
+<p><b>1</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>Station ID</th><th>CSV Row Number</th><th>Parent Station</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>StationB</td><td>8</td><td>StationW</td></tr>\
+</tbody>\
+</table>\
+<p>Please delete the parent station of the station!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -526,7 +526,7 @@ than one `agency_lang`, that\'s an error</p>\
           comparedRouteCsvRowNumber: 2,
           routeLongName: 'RouteApple',
           routeShortName: 'apple',
-          routeType: 'GtfsRouteType.SUBWAY',
+          routeType: 'SUBWAY',
           agencyId: 'agency3'
         },
         {
@@ -536,7 +536,7 @@ than one `agency_lang`, that\'s an error</p>\
           comparedRouteCsvRowNumber: 11,
           routeLongName: 'RoutePear',
           routeShortName: 'pear',
-          routeType: 'GtfsRouteType.BUS',
+          routeType: 'BUS',
           agencyId: 'agency1'
         }
       ]
@@ -551,8 +551,8 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><th>Route ID</th><th>Route CSV Row Number</th><th>Compared Route ID</th><th>Compared Route CSV Row Number</th><th>Route Long Name</th><th>Route Short Name</th><th>Route Type</th><th>Agency ID</th></tr>\
 </thead>\
 <tbody>\
-<tr><td>routeC</td><td>8</td><td>routeF</td><td>2</td><td>RouteApple</td><td>apple</td><td>GtfsRouteType.SUBWAY</td><td>agency3</td></tr>\
-<tr><td>routeW</td><td>15</td><td>routeV</td><td>11</td><td>RoutePear</td><td>pear</td><td>GtfsRouteType.BUS</td><td>agency1</td></tr>\
+<tr><td>routeC</td><td>8</td><td>routeF</td><td>2</td><td>RouteApple</td><td>apple</td><td>SUBWAY</td><td>agency3</td></tr>\
+<tr><td>routeW</td><td>15</td><td>routeV</td><td>11</td><td>RoutePear</td><td>pear</td><td>BUS</td><td>agency1</td></tr>\
 </tbody>\
 </table>\
 <p>Please change the long name or short name of the route to make it unique!</p>\

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -513,6 +513,53 @@ than one `agency_lang`, that\'s an error</p>\
        expect(document.getElementById('error').innerHTML).toContain(output);
      });
 
+  /** Test for route unique names notice */
+  it('should issue route without unique names error', function() {
+    const params = {
+      code: 'route_without_unique_names',
+      totalNotices: 2,
+      notices: [
+        {
+          routeId: 'routeC',
+          routeCsvRowNumber: 8,
+          comparedRouteId: 'routeF',
+          comparedRouteCsvRowNumber: 2,
+          routeLongName: 'RouteApple',
+          routeShortName: 'apple',
+          routeType: 'GtfsRouteType.SUBWAY',
+          agencyId: 'agency3'
+        },
+        {
+          routeId: 'routeW',
+          routeCsvRowNumber: 15,
+          comparedRouteId: 'routeV',
+          comparedRouteCsvRowNumber: 11,
+          routeLongName: 'RoutePear',
+          routeShortName: 'pear',
+          routeType: 'GtfsRouteType.BUS',
+          agencyId: 'agency1'
+        }
+      ]
+    };
+    route_unique_names(params);
+    const output =
+        '<div><p class="error">Error - Route without unique names!</p>\
+<p>Description: The combination of long name, short name, route type and agency ID for a route is not unique.</p>\
+<p><b>2</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>Route ID</th><th>Route CSV Row Number</th><th>Compared Route ID</th><th>Compared Route CSV Row Number</th><th>Route Long Name</th><th>Route Short Name</th><th>Route Type</th><th>Agency ID</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>routeC</td><td>8</td><td>routeF</td><td>2</td><td>RouteApple</td><td>apple</td><td>GtfsRouteType.SUBWAY</td><td>agency3</td></tr>\
+<tr><td>routeW</td><td>15</td><td>routeV</td><td>11</td><td>RoutePear</td><td>pear</td><td>GtfsRouteType.BUS</td><td>agency1</td></tr>\
+</tbody>\
+</table>\
+<p>Please change the long name or short name of the route to make it unique!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [


### PR DESCRIPTION
I have changed the route type field in the notice from GtfsRouteType type to be the corresponding String type, to make it more convenient to use in the soy template.
Template looks like:
<img width="586" alt="Screen Shot 2021-02-12 at 2 14 58 pm" src="https://user-images.githubusercontent.com/41321808/107726368-cb3a6800-6d3c-11eb-84cb-6efbf0ff6c38.png">