### PR TITLE
Validator rule to check that transfers are unique

### DIFF
--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/TransfersAreUniqueNotice.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/TransfersAreUniqueNotice.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class TransfersAreUniqueNotice extends Notice {
+  public TransfersAreUniqueNotice(
+      String fromStopId,
+      String toStopId,
+      long duplicateCsvRowNumber,
+      long originalCsvRowNumber) {
+    super(
+        new ImmutableMap.Builder<String, Object>()
+            .put("fromStopId", fromStopId)
+            .put("toStopId", toStopId)
+            .put("csvRowNumber", duplicateCsvRowNumber)
+            .put("originalCsvRowNumber", originalCsvRowNumber)
+            .build());
+  }
+
+  @Override
+  public String getCode() {
+    return "transfers_are_unique";
+  }
+}

--- a/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidator.java
+++ b/gtfs-validator/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.auto.value.AutoValue;
+import java.util.HashMap;
+import java.util.Map;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.TransfersAreUniqueNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableContainer;
+
+/** Uses AutoValue to create an object with from_stop and to_stop. */
+@AutoValue
+abstract class FromToStopIdentifier {
+  static FromToStopIdentifier create(String fromStopId, String toStopId) {
+    return new AutoValue_FromToStopIdentifier(fromStopId, toStopId);
+  }
+
+  abstract String fromStopId();
+
+  abstract String toStopId();
+}
+
+/**
+ * Validates that transfers are unique.
+ *
+ * <p>Generated notices: {@link TransfersAreUniqueNotice}.
+ */
+@GtfsValidator
+public class TransfersAreUniqueValidator extends FileValidator {
+  @Inject GtfsTransferTableContainer transferTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    // Create Hash Map to store (key: fromToStop object, value: csvRowNumber).
+    final Map<FromToStopIdentifier, Long> stopTransferMap = new HashMap<>();
+    for (GtfsTransfer transfer : transferTable.getEntities()) {
+      // Create fromToStopIdentifier object using the fromStopId and toStopId from each transfer.
+      FromToStopIdentifier fromToStop =
+          FromToStopIdentifier.create(transfer.fromStopId(), transfer.toStopId());
+      // If the hash map already contains the same fromToStop, create a notice.
+      if (stopTransferMap.containsKey(fromToStop)) {
+        noticeContainer.addNotice(new TransfersAreUniqueNotice(
+            /* fromStopId= */ fromToStop.fromStopId(),
+            /* toStopId= */ fromToStop.toStopId(),
+            /* duplicateCsvRowNumber= */ transfer.csvRowNumber(),
+            /* originalCsvRowNUmber= */ stopTransferMap.get(fromToStop)));
+      } else {
+        // If the hash map does not contain the fromToStop, the transfer is unique. Add the transfer
+        // into the hash map.
+        stopTransferMap.put(fromToStop, transfer.csvRowNumber());
+      }
+    }
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
@@ -103,7 +103,7 @@ public class TransfersAreUniqueValidatorTest {
   }
 
   @Test
-  public void moreDuplicateTransfersShouldGenerateNotice() {
+  public void anotherDuplicateTransferShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
     List<GtfsTransfer> transfers =
         new ArrayList<>(Arrays.asList(transfer_1_duplicate, transfer_2, transfer_3, transfer_1));

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -62,7 +63,7 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void allDifferentTransfersShouldNotGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers = Arrays.asList(transfer_1, transfer_2, transfer_3);
+    List<GtfsTransfer> transfers = ImmutableList.of(transfer_1, transfer_2, transfer_3);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices()).isEmpty();
@@ -71,7 +72,7 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void onlyDuplicateTransfersShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers = Arrays.asList(transfer_1, transfer_1_duplicate);
+    List<GtfsTransfer> transfers = ImmutableList.of(transfer_1, transfer_1_duplicate);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())
@@ -85,7 +86,7 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void someDuplicateTransfersShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers = Arrays.asList(
+    List<GtfsTransfer> transfers = ImmutableList.of(
         transfer_1, transfer_2, transfer_3, transfer_1_duplicate, transfer_2_duplicate);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
@@ -106,7 +107,7 @@ public class TransfersAreUniqueValidatorTest {
   public void anotherDuplicateTransferShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
     List<GtfsTransfer> transfers =
-        Arrays.asList(transfer_1_duplicate, transfer_2, transfer_3, transfer_1);
+        ImmutableList.of(transfer_1_duplicate, transfer_2, transfer_3, transfer_1);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.TransfersAreUniqueNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableContainer;
+
+@RunWith(JUnit4.class)
+public class TransfersAreUniqueValidatorTest {
+  private TransfersAreUniqueValidator validator = new TransfersAreUniqueValidator();
+  private final GtfsTransfer transfer_1 = new GtfsTransfer.Builder()
+                                              .setFromStopId("stop_1")
+                                              .setToStopId("stop_2")
+                                              .setCsvRowNumber(1)
+                                              .build();
+  private final GtfsTransfer transfer_1_duplicate = new GtfsTransfer.Builder()
+                                                        .setFromStopId("stop_1")
+                                                        .setToStopId("stop_2")
+                                                        .setCsvRowNumber(10)
+                                                        .build();
+  private final GtfsTransfer transfer_2 = new GtfsTransfer.Builder()
+                                              .setFromStopId("stop_3")
+                                              .setToStopId("stop_7")
+                                              .setCsvRowNumber(2)
+                                              .build();
+  private final GtfsTransfer transfer_2_duplicate = new GtfsTransfer.Builder()
+                                                        .setFromStopId("stop_3")
+                                                        .setToStopId("stop_7")
+                                                        .setCsvRowNumber(4)
+                                                        .build();
+  private final GtfsTransfer transfer_3 = new GtfsTransfer.Builder()
+                                              .setFromStopId("stop_5")
+                                              .setToStopId("stop_9")
+                                              .setCsvRowNumber(3)
+                                              .build();
+
+  @Test
+  public void allDifferentTransfersShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTransfer> transfers =
+        new ArrayList<>(Arrays.asList(transfer_1, transfer_2, transfer_3));
+    validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
+  }
+
+  @Test
+  public void onlyDuplicateTransfersShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTransfer> transfers = new ArrayList<>(Arrays.asList(transfer_1, transfer_1_duplicate));
+    validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(new TransfersAreUniqueNotice(
+            /* fromStopId= */ "stop_1",
+            /* toStopId= */ "stop_2",
+            /* duplicateCsvRowNumber= */ 10,
+            /* originalCsvRowNumber= */ 1));
+  }
+
+  @Test
+  public void someDuplicateTransfersShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTransfer> transfers = new ArrayList<>(Arrays.asList(
+        transfer_1, transfer_2, transfer_3, transfer_1_duplicate, transfer_2_duplicate));
+    validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(new TransfersAreUniqueNotice(
+                             /* fromStopId= */ "stop_1",
+                             /* toStopId= */ "stop_2",
+                             /* duplicateCsvRowNumber= */ 10,
+                             /* originalCsvRowNumber= */ 1),
+            new TransfersAreUniqueNotice(
+                /* fromStopId= */ "stop_3",
+                /* fromStopId= */ "stop_7",
+                /* duplicateCsvRowNumber= */ 4,
+                /* originalCsvRowNumber= */ 2));
+  }
+
+  @Test
+  public void moreDuplicateTransfersShouldGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTransfer> transfers =
+        new ArrayList<>(Arrays.asList(transfer_1_duplicate, transfer_2, transfer_3, transfer_1));
+    validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices())
+        .containsExactly(new TransfersAreUniqueNotice(
+            /* fromStopId= */ "stop_1",
+            /* toStopId= */ "stop_2",
+            /* duplicateCsvRowNumber= */ 1,
+            /* originalCsvRowNumber= */ 10));
+  }
+}

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -61,8 +62,7 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void allDifferentTransfersShouldNotGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers =
-        new ArrayList<>(Arrays.asList(transfer_1, transfer_2, transfer_3));
+    List<GtfsTransfer> transfers = Arrays.asList(transfer_1, transfer_2, transfer_3);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices()).isEmpty();
@@ -71,7 +71,7 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void onlyDuplicateTransfersShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers = new ArrayList<>(Arrays.asList(transfer_1, transfer_1_duplicate));
+    List<GtfsTransfer> transfers = Arrays.asList(transfer_1, transfer_1_duplicate);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())
@@ -85,8 +85,8 @@ public class TransfersAreUniqueValidatorTest {
   @Test
   public void someDuplicateTransfersShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
-    List<GtfsTransfer> transfers = new ArrayList<>(Arrays.asList(
-        transfer_1, transfer_2, transfer_3, transfer_1_duplicate, transfer_2_duplicate));
+    List<GtfsTransfer> transfers = Arrays.asList(
+        transfer_1, transfer_2, transfer_3, transfer_1_duplicate, transfer_2_duplicate);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())
@@ -106,7 +106,7 @@ public class TransfersAreUniqueValidatorTest {
   public void anotherDuplicateTransferShouldGenerateNotice() {
     final NoticeContainer noticeContainer = new NoticeContainer();
     List<GtfsTransfer> transfers =
-        new ArrayList<>(Arrays.asList(transfer_1_duplicate, transfer_2, transfer_3, transfer_1));
+        Arrays.asList(transfer_1_duplicate, transfer_2, transfer_3, transfer_1);
     validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
     validator.validate(noticeContainer);
     assertThat(noticeContainer.getNotices())

--- a/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
+++ b/gtfs-validator/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransfersAreUniqueValidatorTest.java
@@ -59,6 +59,11 @@ public class TransfersAreUniqueValidatorTest {
                                               .setToStopId("stop_9")
                                               .setCsvRowNumber(3)
                                               .build();
+  private final GtfsTransfer transfer_3_reverse = new GtfsTransfer.Builder()
+                                              .setFromStopId("stop_9")
+                                              .setToStopId("stop_5")
+                                              .setCsvRowNumber(11)
+                                              .build();
 
   @Test
   public void allDifferentTransfersShouldNotGenerateNotice() {
@@ -116,5 +121,15 @@ public class TransfersAreUniqueValidatorTest {
             /* toStopId= */ "stop_2",
             /* duplicateCsvRowNumber= */ 1,
             /* originalCsvRowNumber= */ 10));
+  }
+
+  @Test
+  public void reverseStopsShouldNotGenerateNotice() {
+    final NoticeContainer noticeContainer = new NoticeContainer();
+    List<GtfsTransfer> transfers =
+        ImmutableList.of(transfer_3, transfer_3_reverse);
+    validator.transferTable = GtfsTransferTableContainer.forEntities(transfers, noticeContainer);
+    validator.validate(noticeContainer);
+    assertThat(noticeContainer.getNotices()).isEmpty();
   }
 }


### PR DESCRIPTION
Rule to check if transfers are unique. It uses a for loop, with time complexity O(n), to loop through the transfer list and an object, `FromToStop`, is created using Java's AutoValue with transfer's `from_stop_id` and `to_stop_id` values. A hash map, with `key: FromToStop` and `value: csvRowNumber,` is then used to store the `FromToStop` and its corresponding csv row number. A hash map was used instead of another array because the average time complexity of input and search is O(1). If another array was used, we would need to loop through the whole array to check if a value is unique and the time complexity for that would be O(n). Therefore using hash maps would have an overall time complexity of O(n) and using arrays would give us overall time complexity of O(n^2) and thus hash maps are more cost efficient.

An if statement then checks if the created fromToStop already exists in the hash map. If it does exist, it will create a notice with `from_stop_id`, `to_stop_id`, the existing `csvRowNumber` and the duplicated `csvRowNumber`. If the hash map does not contain the `fromToStop` object, it will be added into the hash map with its corresponding `csvRowNumber`.