### PR TITLE
Template for start and end time out of order

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -137,3 +137,9 @@ function station_with_parent_station(params) {
       validator.templates.stationWithParentStation, params);
   document.getElementById('error').appendChild(template);
 }
+
+function start_and_end_time_out_of_order(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.startAndEndTimeOutOfOrder, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -552,3 +552,38 @@
   <p>Please delete the parent station of the station!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the start and end time out of order notice.
+ * @param notices : List<[filename : string, csvRowNumber : number, entityId : string, startTime : string, endTime : string]>
+ */
+{template .startAndEndTimeOutOfOrder}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Start and end time out of order!</p>
+  <p>Description: start_time is after the end_time for a single entity.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>File Name</th>
+        <th>CSV Row Number</th>
+        <th>Entity ID</th>
+        <th>Start Time</th>
+        <th>End Time</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.filename}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.entityId}</td>
+          <td>{$notice.startTime}</td>
+          <td>{$notice.endTime}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please adjust the start time or end time of the entity!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -560,7 +560,7 @@
 {template .startAndEndTimeOutOfOrder}
 {let $numNotices: length($notices)/}
   <p class="error">Error - Start and end time out of order!</p>
-  <p>Description: start_time is after the end_time for a single entity.</p>
+  <p>Description: start_time is after the end_time for a row in frequencies.txt.</p>
   <p><b>{$numNotices}</b> found:</p>
   <table>
     <thead>

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -539,6 +539,37 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for start and end time out of order notice */
+  it('should issue start and end time out of order error', function() {
+    const params = {
+      code: 'start_and_end_time_out_of_order',
+      totalNotices: 1,
+      notices: [{
+        filename: 'stop_times.txt',
+        csvRowNumber: 12,
+        entityId: 'stopC',
+        startTime: '14:20:10',
+        endTime: '14:00:10'
+      }]
+    };
+    start_and_end_time_out_of_order(params);
+    const output =
+        '<div><p class="error">Error - Start and end time out of order!</p>\
+<p>Description: start_time is after the end_time for a single entity.</p>\
+<p><b>1</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>File Name</th><th>CSV Row Number</th><th>Entity ID</th><th>Start Time</th><th>End Time</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>stop_times.txt</td><td>12</td><td>stopC</td><td>14:20:10</td><td>14:00:10</td></tr>\
+</tbody>\
+</table>\
+<p>Please adjust the start time or end time of the entity!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -545,9 +545,9 @@ than one `agency_lang`, that\'s an error</p>\
       code: 'start_and_end_time_out_of_order',
       totalNotices: 1,
       notices: [{
-        filename: 'stop_times.txt',
+        filename: 'frequencies.txt',
         csvRowNumber: 12,
-        entityId: 'stopC',
+        entityId: 'frequencyC',
         startTime: '14:20:10',
         endTime: '14:00:10'
       }]
@@ -555,14 +555,14 @@ than one `agency_lang`, that\'s an error</p>\
     start_and_end_time_out_of_order(params);
     const output =
         '<div><p class="error">Error - Start and end time out of order!</p>\
-<p>Description: start_time is after the end_time for a single entity.</p>\
+<p>Description: start_time is after the end_time for a row in frequencies.txt.</p>\
 <p><b>1</b> found:</p>\
 <table>\
 <thead>\
 <tr><th>File Name</th><th>CSV Row Number</th><th>Entity ID</th><th>Start Time</th><th>End Time</th></tr>\
 </thead>\
 <tbody>\
-<tr><td>stop_times.txt</td><td>12</td><td>stopC</td><td>14:20:10</td><td>14:00:10</td></tr>\
+<tr><td>frequencies.txt</td><td>12</td><td>frequencyC</td><td>14:20:10</td><td>14:00:10</td></tr>\
 </tbody>\
 </table>\
 <p>Please adjust the start time or end time of the entity!</p>\


### PR DESCRIPTION
The template looks like:
<img width="417" alt="Screen Shot 2021-02-12 at 5 26 56 pm" src="https://user-images.githubusercontent.com/41321808/107737005-87089100-6d57-11eb-9faf-f4df18bbda5b.png">
The codes have already been run through clang-format.