### PR TITLE
Template for Start and end date out of order

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -143,3 +143,9 @@ function start_and_end_time_out_of_order(params) {
       validator.templates.startAndEndTimeOutOfOrder, params);
   document.getElementById('error').appendChild(template);
 }
+
+function start_and_end_date_out_of_order(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.startAndEndDateOutOfOrder, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -587,3 +587,36 @@
   <p>Please adjust the start time or end time of the entity!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the start and end date out of order notice.
+ * @param notices : List<[filename : string, csvRowNumber : number, entityId : string, startDate : string, endDate : string]>
+ */
+{template .startAndEndDateOutOfOrder}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Start and end date out of order!</p>
+  <p>Description: Start date is later than the end date.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>File Name</th>
+        <th>CSV Row Number</th>
+        <th>Start Date</th>
+        <th>End Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.filename}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.startDate}</td>
+          <td>{$notice.endDate}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please adjust the start or the end date!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -570,6 +570,45 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for start and end date out of order notice */
+  it('should issue start and end date out of order error', function() {
+    const params = {
+      code: 'start_and_end_date_out_of_order',
+      totalNotices: 2,
+      notices: [
+        {
+          filename: 'calendar.txt',
+          csvRowNumber: 3,
+          startDate: '20201230',
+          endDate: '20201129'
+        },
+        {
+          filename: 'feed_info.txt',
+          csvRowNumber: 4,
+          startDate: '20190121',
+          endDate: '20181230'
+        }
+      ]
+    };
+    start_and_end_date_out_of_order(params);
+    const output =
+        '<div><p class="error">Error - Start and end date out of order!</p>\
+<p>Description: Start date is later than the end date.</p>\
+<p><b>2</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>File Name</th><th>CSV Row Number</th><th>Start Date</th><th>End Date</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>calendar.txt</td><td>3</td><td>20201230</td><td>20201129</td></tr>\
+<tr><td>feed_info.txt</td><td>4</td><td>20190121</td><td>20181230</td></tr>\
+</tbody>\
+</table>\
+<p>Please adjust the start or the end date!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [


### PR DESCRIPTION
The template looks like:
<img width="341" alt="Screen Shot 2021-02-12 at 5 43 55 pm" src="https://user-images.githubusercontent.com/41321808/107738038-026b4200-6d5a-11eb-94f1-bb1aff5a090b.png">

The codes have already been run through clang-format.