### PR TITLE
Template for the same route name and description

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -149,3 +149,9 @@ function start_and_end_date_out_of_order(params) {
       validator.templates.startAndEndDateOutOfOrder, params);
   document.getElementById('error').appendChild(template);
 }
+
+function same_route_name_and_description(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.sameNameAndDescriptionForRoute, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -628,7 +628,7 @@
 {template .sameNameAndDescriptionForRoute}
 {let $numNotices: length($notices)/}
   <p class="error">Error - Same route name and description!</p>
-  <p>Description: Name and description for the route are the same.</p>
+  <p>Description: Name and description of the route are the same.</p>
   <p><b>{$numNotices}</b> found:</p>
   <table>
     <thead>
@@ -652,6 +652,6 @@
       {/foreach}
     </tbody>
   </table>
-  <p>Please adjust the specified name or the description for the route to make them different!</p>
+  <p>Please adjust the specified name or the description of the route to make them different!</p>
   <br><br>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -652,6 +652,6 @@
       {/foreach}
     </tbody>
   </table>
-  <p>Please adjust the name or the description for the route to make them different!</p>
+  <p>Please adjust the specified name or the description for the route to make them different!</p>
   <br><br>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -620,3 +620,38 @@
   <p>Please adjust the start or the end date!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the same route name and description notice.
+ * @param notices : List<[filename : string, routeId : string, csvRowNumber : number, routeDesc : string, specifiedField : string]>
+ */
+{template .sameNameAndDescriptionForRoute}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Same route name and description!</p>
+  <p>Description: Name and description for the route are the same.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>File Name</th>
+        <th>Route ID</th>
+        <th>CSV Row Number</th>
+        <th>Route Description</th>
+        <th>Specified Field</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.filename}</td>
+          <td>{$notice.routeId}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.routeDesc}</td>
+          <td>{$notice.specifiedField}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please adjust the name or the description for the route to make them different!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -609,6 +609,47 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for the same route name and description notice */
+  it('should issue the same route name and description error', function() {
+    const params = {
+      code: 'same_route_name_and_description',
+      totalNotices: 2,
+      notices: [
+        {
+          filename: 'FILENAME',
+          routeId: 'RouteB',
+          csvRowNumber: 12,
+          routeDesc: 'RouteFromAppleBlockToOrangeBlock',
+          specifiedField: 'route_short_name'
+        },
+        {
+          filename: 'FILENAME',
+          routeId: 'RouteP',
+          csvRowNumber: 4,
+          routeDesc: 'Route12345',
+          specifiedField: 'route_long_name'
+        }
+      ]
+    };
+    same_route_name_and_description(params);
+    const output =
+        '<div><p class="error">Error - Same route name and description!</p>\
+<p>Description: Name and description for the route are the same.</p>\
+<p><b>2</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>File Name</th><th>Route ID</th><th>CSV Row Number</th><th>Route Description</th><th>Specified Field</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>FILENAME</td><td>RouteB</td><td>12</td><td>RouteFromAppleBlockToOrangeBlock</td><td>route_short_name</td></tr>\
+<tr><td>FILENAME</td><td>RouteP</td><td>4</td><td>Route12345</td><td>route_long_name</td></tr>\
+</tbody>\
+</table>\
+<p>Please adjust the name or the description for the route to make them different!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -634,7 +634,7 @@ than one `agency_lang`, that\'s an error</p>\
     same_route_name_and_description(params);
     const output =
         '<div><p class="error">Error - Same route name and description!</p>\
-<p>Description: Name and description for the route are the same.</p>\
+<p>Description: Name and description of the route are the same.</p>\
 <p><b>2</b> found:</p>\
 <table>\
 <thead>\
@@ -645,7 +645,7 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><td>FILENAME</td><td>RouteP</td><td>4</td><td>Route12345</td><td>route_long_name</td></tr>\
 </tbody>\
 </table>\
-<p>Please adjust the specified name or the description for the route to make them different!</p>\
+<p>Please adjust the specified name or the description of the route to make them different!</p>\
 <br><br></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -645,7 +645,7 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><td>FILENAME</td><td>RouteP</td><td>4</td><td>Route12345</td><td>route_long_name</td></tr>\
 </tbody>\
 </table>\
-<p>Please adjust the name or the description for the route to make them different!</p>\
+<p>Please adjust the specified name or the description for the route to make them different!</p>\
 <br><br></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });


### PR DESCRIPTION
The template looks like:
<img width="582" alt="Screen Shot 2021-02-12 at 6 09 25 pm" src="https://user-images.githubusercontent.com/41321808/107739669-84a93580-6d5d-11eb-8024-4f2c6d939f83.png">

The codes have already been run through clang-format.