### PR TITLE
Template for route both short and long name missing

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -137,3 +137,9 @@ function station_with_parent_station(params) {
       validator.templates.stationWithParentStation, params);
   document.getElementById('error').appendChild(template);
 }
+
+function route_both_short_and_long_name_missing(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.routeBothShortAndLongNameMissing, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -559,25 +559,27 @@
  */
 {template .routeBothShortAndLongNameMissing}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Route short and long name missing!</p>
-  <p>Description: Both the short name and long name of the route are missing.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Route ID</th>
-        <th>CSV Row Number</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#routeBothShortAndLongNameMissing" class="error collapsed">Error - Route short and long name missing!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="routeBothShortAndLongNameMissing">
+    <p>Description: Both the short name and long name of the route are missing.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.csvRowNumber}</td>
+          <th>Route ID</th>
+          <th>CSV Row Number</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please add a short name or a long name for the route!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.csvRowNumber}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please add a short name or a long name for the route!</p>
+    <br><br>
+  </div>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -552,3 +552,32 @@
   <p>Please delete the parent station of the station!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the station with parent station notice.
+ * @param notices : List<[routeId : string, csvRowNumber : number]>
+ */
+{template .routeBothShortAndLongNameMissing}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Route short and long name missing!</p>
+  <p>Description: Both the short name and long name of the route are missing.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Route ID</th>
+        <th>CSV Row Number</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.routeId}</td>
+          <td>{$notice.csvRowNumber}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please add a short name or a long name for the route!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -539,6 +539,32 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test if route is missing both short and long name. */
+  it('should issue error if both short and long route names are missing', function() {
+    const params = {
+      code: 'route_both_short_and_long_name_missing',
+      totalNotices: 1,
+      notices:
+          [{routeId: 'RouteA', csvRowNumber: 8}]
+    };
+    route_both_short_and_long_name_missing(params);
+    const output =
+        '<div><p class="error">Error - Route short and long name missing!</p>\
+<p>Description: Both the short name and long name of the route are missing.</p>\
+<p><b>1</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>Route ID</th><th>CSV Row Number</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>RouteA</td><td>8</td></tr>\
+</tbody>\
+</table>\
+<p>Please add a short name or a long name for the route!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -549,7 +549,8 @@ than one `agency_lang`, that\'s an error</p>\
        };
        route_both_short_and_long_name_missing(params);
        const output =
-           '<div><p class="error">Error - Route short and long name missing!</p>\
+           '<div><button data-toggle="collapse" data-target="#routeBothShortAndLongNameMissing" class="error collapsed">Error - Route short and long name missing!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="routeBothShortAndLongNameMissing">\
 <p>Description: Both the short name and long name of the route are missing.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -561,7 +562,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please add a short name or a long name for the route!</p>\
-<br><br></div>';
+<br><br></div></div>';
        expect(document.getElementById('error').innerHTML).toContain(output);
      });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -540,16 +540,16 @@ than one `agency_lang`, that\'s an error</p>\
   });
 
   /** Test if route is missing both short and long name. */
-  it('should issue error if both short and long route names are missing', function() {
-    const params = {
-      code: 'route_both_short_and_long_name_missing',
-      totalNotices: 1,
-      notices:
-          [{routeId: 'RouteA', csvRowNumber: 8}]
-    };
-    route_both_short_and_long_name_missing(params);
-    const output =
-        '<div><p class="error">Error - Route short and long name missing!</p>\
+  it('should issue error if both short and long route names are missing',
+     function() {
+       const params = {
+         code: 'route_both_short_and_long_name_missing',
+         totalNotices: 1,
+         notices: [{routeId: 'RouteA', csvRowNumber: 8}]
+       };
+       route_both_short_and_long_name_missing(params);
+       const output =
+           '<div><p class="error">Error - Route short and long name missing!</p>\
 <p>Description: Both the short name and long name of the route are missing.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -562,8 +562,8 @@ than one `agency_lang`, that\'s an error</p>\
 </table>\
 <p>Please add a short name or a long name for the route!</p>\
 <br><br></div>';
-    expect(document.getElementById('error').innerHTML).toContain(output);
-  });
+       expect(document.getElementById('error').innerHTML).toContain(output);
+     });
 
   it('should call the correct functions', function() {
     const params = JSON.stringify({


### PR DESCRIPTION
Implemented the template for routeBothShortAndLongNamesMissing. 

The code looks like:
![image](https://user-images.githubusercontent.com/75406958/107775676-b7225500-6d94-11eb-8929-c994c9c1fab5.png)
