### PR TITLE
Template for route short and long name equal

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -137,3 +137,9 @@ function station_with_parent_station(params) {
       validator.templates.stationWithParentStation, params);
   document.getElementById('error').appendChild(template);
 }
+
+function route_short_and_long_name_equal(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.routeShortAndLongNameEqual, params);
+  document.getElementById('error').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -559,27 +559,29 @@
  */
 {template .routeShortAndLongNameEqual}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Route Short and Long Name Equal!</p>
-  <p>Description: Both the short and long name of a route are equal.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Route ID</th>
-        <th>CSV Row Number</th>
-        <th>Route Name (short and long)</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#routeShortAndLongNameEqual" class="error collapsed">Error - Route Short and Long Name Equal!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="routeShortAndLongNameEqual">
+    <p>Description: Both the short and long name of a route are equal.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.routeShortName}</td>
+          <th>Route ID</th>
+          <th>CSV Row Number</th>
+          <th>Route Name (short and long)</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please change the short or long name of the route!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.routeShortName}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please change the short or long name of the route!</p>
+    <br><br>
+  </div>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -567,8 +567,7 @@
       <tr>
         <th>Route ID</th>
         <th>CSV Row Number</th>
-        <th>Route Short Name</th>
-        <th>Route Long Name</th>
+        <th>Route Name (short and long)</th>
       </tr>
     </thead>
     <tbody>
@@ -577,7 +576,6 @@
           <td>{$notice.routeId}</td>
           <td>{$notice.csvRowNumber}</td>
           <td>{$notice.routeShortName}</td>
-          <td>{$notice.routeLongName}</td>
         </tr>
       {/foreach}
     </tbody>

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -552,3 +552,36 @@
   <p>Please delete the parent station of the station!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders an explanation when route long and short name are equal.
+ * @param notices : List<[routeId : string, csvRowNumber : number, routeShortName : string, routeLongName : string]>
+ */
+{template .routeShortAndLongNameEqual}
+{let $numNotices: length($notices)/}
+  <p class="error">Error - Route Short and Long Name Equal!</p>
+  <p>Description: Both the short and long name of a route are equal.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Route ID</th>
+        <th>CSV Row Number</th>
+        <th>Route Short Name</th>
+        <th>Route Long Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.routeId}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.routeShortName}</td>
+          <td>{$notice.routeLongName}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please change the short or long name of the route!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -539,6 +539,36 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for route having the same short and long name */
+  it('should issue route short and long name error', function() {
+    const params = {
+      code: 'route_short_and_long_name_equal',
+      totalNotices: 1,
+      notices: [{
+        routeId: 'Route1',
+        csvRowNumber: 2,
+        routeShortName: 'routeName',
+        routeLongName: 'routeName'
+      }]
+    };
+    route_short_and_long_name_equal(params);
+    const output =
+        '<div><p class="error">Error - Route Short and Long Name Equal!</p>\
+<p>Description: Both the short and long name of a route are equal.</p>\
+<p><b>1</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>Route ID</th><th>CSV Row Number</th><th>Route Short Name</th><th>Route Long Name</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>Route1</td><td>2</td><td>routeName</td><td>routeName</td></tr>\
+</tbody>\
+</table>\
+<p>Please change the short or long name of the route!</p>\
+<br><br></div>';
+    expect(document.getElementById('error').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -558,10 +558,10 @@ than one `agency_lang`, that\'s an error</p>\
 <p><b>1</b> found:</p>\
 <table>\
 <thead>\
-<tr><th>Route ID</th><th>CSV Row Number</th><th>Route Short Name</th><th>Route Long Name</th></tr>\
+<tr><th>Route ID</th><th>CSV Row Number</th><th>Route Name (short and long)</th></tr>\
 </thead>\
 <tbody>\
-<tr><td>Route1</td><td>2</td><td>routeName</td><td>routeName</td></tr>\
+<tr><td>Route1</td><td>2</td><td>routeName</td></tr>\
 </tbody>\
 </table>\
 <p>Please change the short or long name of the route!</p>\

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -553,7 +553,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     route_short_and_long_name_equal(params);
     const output =
-        '<div><p class="error">Error - Route Short and Long Name Equal!</p>\
+        '<button data-toggle="collapse" data-target="#routeShortAndLongNameEqual" class="error collapsed">Error - Route Short and Long Name Equal!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="routeShortAndLongNameEqual">\
 <p>Description: Both the short and long name of a route are equal.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -565,7 +566,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please change the short or long name of the route!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 


### PR DESCRIPTION
Template for route short and long name having equal name.

This is what the updated template looks like:
![image](https://user-images.githubusercontent.com/75406958/107999734-4735f800-703c-11eb-9623-64bf706b053b.png)
