### PR TITLE
Template for route short name too long

### DIFF
--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -137,3 +137,9 @@ function station_with_parent_station(params) {
       validator.templates.stationWithParentStation, params);
   document.getElementById('error').appendChild(template);
 }
+
+function route_short_name_too_long(params) {
+  const template = goog.soy.renderAsElement(
+      validator.templates.routeShortNameTooLong, params);
+  document.getElementById('warning').appendChild(template);
+}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -559,27 +559,29 @@
  */
 {template .routeShortNameTooLong}
 {let $numNotices: length($notices)/}
-  <p class="warning">Warning - Route short name too long!</p>
-  <p>Description: The short name of a route is too long.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Route ID</th>
-        <th>CSV Row Number</th>
-        <th>Route Short Name</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+ <button data-toggle="collapse" data-target="#routeShortNameTooLong" class="warning collapsed">Warning - Route short name too long!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="routeShortNameTooLong">
+    <p>Description: The short name of a route is too long.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.routeShortName}</td>
+          <th>Route ID</th>
+          <th>CSV Row Number</th>
+          <th>Route Short Name</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please shorten the route name's short name!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.routeShortName}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please shorten the route name's short name!</p>
+    <br><br>
+  </div>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -552,3 +552,34 @@
   <p>Please delete the parent station of the station!</p>
   <br><br>
 {/template}
+
+/**
+ * Renders a basic explanation of the station with parent station notice.
+ * @param notices : List<[routeId : string, csvRowNumber : number, routeShortName : string]>
+ */
+{template .routeShortNameTooLong}
+{let $numNotices: length($notices)/}
+  <p class="warning">Warning - Route short name too long!</p>
+  <p>Description: The short name of a route is too long.</p>
+  <p><b>{$numNotices}</b> found:</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Route ID</th>
+        <th>CSV Row Number</th>
+        <th>Route Short Name</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach $notice in $notices}
+        <tr>
+          <td>{$notice.routeId}</td>
+          <td>{$notice.csvRowNumber}</td>
+          <td>{$notice.routeShortName}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <p>Please shorten the route name's short name!</p>
+  <br><br>
+{/template}

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -552,7 +552,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     route_short_name_too_long(params);
     const output =
-        '<div><p class="warning">Warning - Route short name too long!</p>\
+        '<button data-toggle="collapse" data-target="#routeShortNameTooLong" class="warning collapsed">Warning - Route short name too long!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="routeShortNameTooLong">\
 <p>Description: The short name of a route is too long.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -564,7 +565,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please shorten the route name\'s short name!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('warning').innerHTML).toContain(output);
   });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -539,6 +539,35 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
+  /** Test for route with short name too long */
+  it('should issue route with short name warning', function() {
+    const params = {
+      code: 'route_short_name_too_long',
+      totalNotices: 1,
+      notices: [{
+        routeId: 'RouteA',
+        csvRowNumber: 5,
+        routeShortName: 'veryLoooooooooonnnnnnnnnnngggggggggName'
+      }]
+    };
+    route_short_name_too_long(params);
+    const output =
+        '<div><p class="warning">Warning - Route short name too long!</p>\
+<p>Description: The short name of a route is too long.</p>\
+<p><b>1</b> found:</p>\
+<table>\
+<thead>\
+<tr><th>Route ID</th><th>CSV Row Number</th><th>Route Short Name</th></tr>\
+</thead>\
+<tbody>\
+<tr><td>RouteA</td><td>5</td><td>veryLoooooooooonnnnnnnnnnngggggggggName</td></tr>\
+</tbody>\
+</table>\
+<p>Please shorten the route name\'s short name!</p>\
+<br><br></div>';
+    expect(document.getElementById('warning').innerHTML).toContain(output);
+  });
+
   it('should call the correct functions', function() {
     const params = JSON.stringify({
       notices: [


### PR DESCRIPTION
Add template for routeShortNameTooLongNotice.

This is what it looks like:
![image](https://user-images.githubusercontent.com/75406958/107789638-f60cd680-6da5-11eb-9a87-bc39c8d65be0.png)
