### PR TITLE
Adjust templates to make notices collapsable 1

### DIFF
--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -115,27 +115,29 @@
  */
 {template .unusedShape}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Unused shape!</p>
-  <p>Description: The shape in shapes.txt is never used by any trip from trips.txt.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Shape ID</th>
-        <th>CSV Row Number</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#unusedShape" class="error collapsed">Error - Unused shape!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="unusedShape">
+    <p>Description: The shape in shapes.txt is never used by any trip from trips.txt.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.shapeId}</td>
-          <td>{$notice.csvRowNumber}</td>
+          <th>Shape ID</th>
+          <th>CSV Row Number</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please delete the unused shape(s)!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.shapeId}</td>
+            <td>{$notice.csvRowNumber}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please delete the unused shape(s)!</p>
+    <br><br>  
+  </div>
 {/template}
 
 /**
@@ -453,37 +455,39 @@
  */
 {template .tripWithDuplicateStops}
 {let $numNotices: length($notices)/}
-  <p class="warning">Warning - Trip with duplicate stops!</p>
-  <p>Description: For a trip, consecutive stop times have the same stop name.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Stop Name</th>
-        <th>Stop ID 1</th>
-        <th>CSV Row Number Stop 1</th>
-        <th>Stop ID 2</th>
-        <th>CSV Row Number Stop 2</th>
-        <th>Route ID</th>
-        <th>Example Trip ID</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#tripWithDuplicateStops" class="warning collapsed">Warning - Trip with duplicate stops!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="tripWithDuplicateStops">
+    <p>Description: For a trip, consecutive stop times have the same stop name.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.stopName}</td>
-          <td>{$notice.stopId1}</td>
-          <td>{$notice.csvRowNumberStop1}</td>
-          <td>{$notice.stopId2}</td>
-          <td>{$notice.csvRowNumberStop2}</td>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.exampleTripId}</td>
+          <th>Stop Name</th>
+          <th>Stop ID 1</th>
+          <th>CSV Row Number Stop 1</th>
+          <th>Stop ID 2</th>
+          <th>CSV Row Number Stop 2</th>
+          <th>Route ID</th>
+          <th>Example Trip ID</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please fix the problem of stop names for the corresponding trip(s)!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.stopName}</td>
+            <td>{$notice.stopId1}</td>
+            <td>{$notice.csvRowNumberStop1}</td>
+            <td>{$notice.stopId2}</td>
+            <td>{$notice.csvRowNumberStop2}</td>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.exampleTripId}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please fix the problem of stop names for the corresponding trip(s)!</p>
+    <br><br>
+  </div>
 {/template} 
 
 /**
@@ -492,33 +496,35 @@
  */
 {template .stopsTooClose}
 {let $numNotices: length($notices)/}
-  <p class="warning">Warning - Stops too close!</p>
-  <p>Description: Two stops are too close with each other.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Stop ID 1</th>
-        <th>CSV Row Number Stop 1</th>
-        <th>Stop ID 2</th>
-        <th>CSV Row Number Stop 2</th>
-        <th>Trip Buffer in Meters</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#stopsTooClose" class="warning collapsed">Warning - Stops too close!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="stopsTooClose">
+    <p>Description: Two stops are too close with each other.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.stopId1}</td>
-          <td>{$notice.csvRowNumberStop1}</td>
-          <td>{$notice.stopId2}</td>
-          <td>{$notice.csvRowNumberStop2}</td>
-          <td>{$notice.tripBufferMeters}</td>
+          <th>Stop ID 1</th>
+          <th>CSV Row Number Stop 1</th>
+          <th>Stop ID 2</th>
+          <th>CSV Row Number Stop 2</th>
+          <th>Trip Buffer in Meters</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please fix the stops positions to make their distance further than the trip buffer meters!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.stopId1}</td>
+            <td>{$notice.csvRowNumberStop1}</td>
+            <td>{$notice.stopId2}</td>
+            <td>{$notice.csvRowNumberStop2}</td>
+            <td>{$notice.tripBufferMeters}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please fix the stops positions to make their distance further than the trip buffer meters!</p>
+    <br><br>
+  </div>
 {/template} 
 
 /**

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -62,7 +62,8 @@ describe('Output', function() {
       ]
     };
     invalid_row_length(params);
-    const output = '<div><button data-toggle="collapse" data-target="#invalidRowLength" class="error collapsed">Error - Invalid csv row length!<span>+</span><p>-</p></button>\
+    const output =
+        '<div><button data-toggle="collapse" data-target="#invalidRowLength" class="error collapsed">Error - Invalid csv row length!<span>+</span><p>-</p></button>\
 <div class="content collapse in" id="invalidRowLength">\
 <p>Description: A row in the input file has a different number of values than specified by the CSV header.</p>\
 <p><b>2</b> found:</p>\
@@ -119,7 +120,9 @@ describe('Output', function() {
       notices: [{shapeId: 'star2', csvRowNumber: 13}]
     };
     unused_shape(params);
-    const output = '<div><p class=\"error"\>Error - Unused shape!</p>\
+    const output =
+        '<div><button data-toggle="collapse" data-target="#unusedShape" class="error collapsed">Error - Unused shape!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="unusedShape">\
 <p>Description: The shape in shapes.txt is never used by any trip from trips.txt.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -130,7 +133,7 @@ describe('Output', function() {
 <tr><td>star2</td><td>13</td></tr>\
 </tbody>\
 </table>\
-<p>Please delete the unused shape(s)!</p><br><br></div>'
+<p>Please delete the unused shape(s)!</p><br><br></div></div>'
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
@@ -265,19 +268,20 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-/** Test for location without parent station notice */
+  /** Test for location without parent station notice */
   it('should issue location without parent station error', function() {
     const params = {
       code: 'location_without_parent_station',
       totalNotices: 1,
       notices: [{
-        stopId: "stop1",
+        stopId: 'stop1',
         csvRowNumber: 15,
         locationType: 1,
       }]
     };
     location_without_parent_station(params);
-    const output = '<p class=\"error\">Error - Location(s) without a parent station found!</p>\
+    const output =
+        '<p class=\"error\">Error - Location(s) without a parent station found!</p>\
 <p>Description: A location that must have `parent_station` field does not have it.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -293,15 +297,15 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-  /** 
-   * Test for meaningless trip notice 
+  /**
+   * Test for meaningless trip notice
    * */
   it('should issue meaingless trip error', function() {
     const params = {
       code: 'meaningless_trip_with_no_more_than_one_stop',
       totalNotices: 1,
       notices: [{
-        tripId: "trip1",
+        tripId: 'trip1',
         csvRowNumber: 15,
       }]
     };
@@ -321,22 +325,23 @@ than one `agency_lang`, that\'s an error</p>\
 <br><br>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
-  /** 
-   * Test for missing trip edge arrival or departure time 
+  /**
+   * Test for missing trip edge arrival or departure time
    * */
   it('should issue missing trip edge stop time error', function() {
     const params = {
       code: 'missing_trip_edge_arrival_time_departure_time',
       totalNotices: 1,
       notices: [{
-        tripId: "Trip1",
+        tripId: 'Trip1',
         csvRowNumber: 21,
-        arrivalOrDepartureTime: "Arrival",
+        arrivalOrDepartureTime: 'Arrival',
         stopSequence: 21
       }]
     };
     missing_trip_edge_arrival_time_departure_time(params);
-    const output = '<p class="error">Error - Missing arrival or departure time for trip(s)!</p>\
+    const output =
+        '<p class="error">Error - Missing arrival or departure time for trip(s)!</p>\
 <p>Description: The first and last stop for each trip should have both an arrival and departure time.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -352,7 +357,7 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-  /** 
+  /**
    * Test for overlapping frequency
    * */
   it('should issue overlapping frequency error', function() {
@@ -360,15 +365,16 @@ than one `agency_lang`, that\'s an error</p>\
       code: 'overlapping_frequency',
       totalNotices: 1,
       notices: [{
-        tripId: "Trip1",
+        tripId: 'Trip1',
         prevCsvRowNumber: 18,
-        prevEndTime: "18:00:00",
+        prevEndTime: '18:00:00',
         currCsvRowNumber: 19,
-        currStartTime:  "18:00:00"
+        currStartTime: '18:00:00'
       }]
     };
     overlapping_frequency(params);
-    const output = '<p class="error">Error - Overlapping frequency entries found!</p>\
+    const output =
+        '<p class="error">Error - Overlapping frequency entries found!</p>\
 <p>Description: Two frequency entries referring to the same trip may not have an overlapping time range.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -441,7 +447,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     trip_with_duplicate_stops(params);
     const output =
-        '<div><p class=\"warning"\>Warning - Trip with duplicate stops!</p>\
+        '<div><button data-toggle="collapse" data-target="#tripWithDuplicateStops" class="warning collapsed">Warning - Trip with duplicate stops!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="tripWithDuplicateStops">\
 <p>Description: For a trip, consecutive stop times have the same stop name.</p>\
 <p><b>2</b> found:</p>\
 <table>\
@@ -453,7 +460,7 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><td>OrangeStop</td><td>stop305</td><td>7</td><td>stop308</td><td>8</td><td>routeC</td><td>trip3</td></tr>\
 </tbody>\
 </table>\
-<p>Please fix the problem of stop names for the corresponding trip(s)!</p><br><br></div>'
+<p>Please fix the problem of stop names for the corresponding trip(s)!</p><br><br></div></div>'
     expect(document.getElementById('warning').innerHTML).toContain(output);
   });
 
@@ -487,7 +494,9 @@ than one `agency_lang`, that\'s an error</p>\
       ]
     };
     stops_too_close(params);
-    const output = '<div><p class=\"warning"\>Warning - Stops too close!</p>\
+    const output =
+        '<div><button data-toggle="collapse" data-target="#stopsTooClose" class="warning collapsed">Warning - Stops too close!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="stopsTooClose">\
 <p>Description: Two stops are too close with each other.</p>\
 <p><b>3</b> found:</p>\
 <table>\
@@ -500,7 +509,7 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><td>stop501</td><td>1</td><td>stop507</td><td>5</td><td>5</td></tr>\
 </tbody>\
 </table>\
-<p>Please fix the stops positions to make their distance further than the trip buffer meters!</p><br><br></div>'
+<p>Please fix the stops positions to make their distance further than the trip buffer meters!</p><br><br></div></div>'
     expect(document.getElementById('warning').innerHTML).toContain(output);
   });
 


### PR DESCRIPTION
For 3 notices: UnusedShapeNotice; TripWithDuplicateStopNotice; StopsTooCloseNotice.

Soy templates are adjusted a bit at the very beginning for each notice. Tests' html contents are changed a little according to that. Auto-formatting has been run through.

```
<button data-toggle="collapse" data-target="#xxxxxxxxxx" class="???? collapsed">???? - xxxxx!<span>+</span><p>-</p></button>
<div class="content collapse in" id="xxxxxxxxxx">
  ..........
</div>
```