### PR TITLE
Adjust templates to make notices collapsable 3

### DIFF
--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -630,33 +630,35 @@
  */
 {template .stopTimeWithArrivalBeforePreviousDepartureTime}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Stop time with arrival before previous departure time!</p>
-  <p>Description: Arrival for the stop time is before its corresponding previous departure time.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>CSV Row Number</th>
-        <th>Previous CSV Row Number</th>
-        <th>Trip ID</th>
-        <th>Previous Departure Time</th>
-        <th>Arrival Time</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#stopTimeWithArrivalBeforePreviousDepartureTime" class="error collapsed">Error - Stop time with arrival before previous departure time!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="stopTimeWithArrivalBeforePreviousDepartureTime">
+    <p>Description: Arrival for the stop time is before its corresponding previous departure time.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.prevCsvRowNumber}</td>
-          <td>{$notice.tripId}</td>
-          <td>{$notice.departureTime}</td>
-          <td>{$notice.arrivalTime}</td>
+          <th>CSV Row Number</th>
+          <th>Previous CSV Row Number</th>
+          <th>Trip ID</th>
+          <th>Previous Departure Time</th>
+          <th>Arrival Time</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please fix the arrival time or the previous departure time for the stop time!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.prevCsvRowNumber}</td>
+            <td>{$notice.tripId}</td>
+            <td>{$notice.departureTime}</td>
+            <td>{$notice.arrivalTime}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please fix the arrival time or the previous departure time for the stop time!</p>
+    <br><br>
+  </div>
 {/template}
 
 /**

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -708,29 +708,31 @@
  */
 {template .stationWithParentStation}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Station with parent station!</p>
-  <p>Description: A station has parent_station field set.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Station ID</th>
-        <th>CSV Row Number</th>
-        <th>Parent Station</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#stationWithParentStation" class="error collapsed">Error - Station with parent station!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="stationWithParentStation">
+    <p>Description: A station has parent_station field set.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.stopId}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.parentStation}</td>
+          <th>Station ID</th>
+          <th>CSV Row Number</th>
+          <th>Parent Station</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please delete the parent station of the station!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.stopId}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.parentStation}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please delete the parent station of the station!</p>
+    <br><br>
+  </div>
 {/template}
 
 /**

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -741,33 +741,35 @@
  */
 {template .startAndEndTimeOutOfOrder}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Start and end time out of order!</p>
-  <p>Description: start_time is after the end_time for a row in frequencies.txt.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>File Name</th>
-        <th>CSV Row Number</th>
-        <th>Entity ID</th>
-        <th>Start Time</th>
-        <th>End Time</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#startAndEndTimeOutOfOrder" class="error collapsed">Error - Start and end time out of order!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="startAndEndTimeOutOfOrder">
+    <p>Description: start_time is after the end_time for a row in frequencies.txt.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.filename}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.entityId}</td>
-          <td>{$notice.startTime}</td>
-          <td>{$notice.endTime}</td>
+          <th>File Name</th>
+          <th>CSV Row Number</th>
+          <th>Entity ID</th>
+          <th>Start Time</th>
+          <th>End Time</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please adjust the start time or end time of the entity!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.filename}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.entityId}</td>
+            <td>{$notice.startTime}</td>
+            <td>{$notice.endTime}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please adjust the start time or end time of the entity!</p>
+    <br><br>
+  </div>
 {/template}
 
 /**

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -693,7 +693,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     station_with_parent_station(params);
     const output =
-        '<div><p class="error">Error - Station with parent station!</p>\
+        '<div><button data-toggle="collapse" data-target="#stationWithParentStation" class="error collapsed">Error - Station with parent station!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="stationWithParentStation">\
 <p>Description: A station has parent_station field set.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -705,7 +706,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please delete the parent station of the station!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -62,7 +62,8 @@ describe('Output', function() {
       ]
     };
     invalid_row_length(params);
-    const output = '<div><button data-toggle="collapse" data-target="#invalidRowLength" class="error collapsed">Error - Invalid csv row length!<span>+</span><p>-</p></button>\
+    const output =
+        '<div><button data-toggle="collapse" data-target="#invalidRowLength" class="error collapsed">Error - Invalid csv row length!<span>+</span><p>-</p></button>\
 <div class="content collapse in" id="invalidRowLength">\
 <p>Description: A row in the input file has a different number of values than specified by the CSV header.</p>\
 <p><b>2</b> found:</p>\
@@ -265,19 +266,20 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-/** Test for location without parent station notice */
+  /** Test for location without parent station notice */
   it('should issue location without parent station error', function() {
     const params = {
       code: 'location_without_parent_station',
       totalNotices: 1,
       notices: [{
-        stopId: "stop1",
+        stopId: 'stop1',
         csvRowNumber: 15,
         locationType: 1,
       }]
     };
     location_without_parent_station(params);
-    const output = '<p class=\"error\">Error - Location(s) without a parent station found!</p>\
+    const output =
+        '<p class=\"error\">Error - Location(s) without a parent station found!</p>\
 <p>Description: A location that must have `parent_station` field does not have it.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -293,15 +295,15 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-  /** 
-   * Test for meaningless trip notice 
+  /**
+   * Test for meaningless trip notice
    * */
   it('should issue meaingless trip error', function() {
     const params = {
       code: 'meaningless_trip_with_no_more_than_one_stop',
       totalNotices: 1,
       notices: [{
-        tripId: "trip1",
+        tripId: 'trip1',
         csvRowNumber: 15,
       }]
     };
@@ -321,22 +323,23 @@ than one `agency_lang`, that\'s an error</p>\
 <br><br>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
-  /** 
-   * Test for missing trip edge arrival or departure time 
+  /**
+   * Test for missing trip edge arrival or departure time
    * */
   it('should issue missing trip edge stop time error', function() {
     const params = {
       code: 'missing_trip_edge_arrival_time_departure_time',
       totalNotices: 1,
       notices: [{
-        tripId: "Trip1",
+        tripId: 'Trip1',
         csvRowNumber: 21,
-        arrivalOrDepartureTime: "Arrival",
+        arrivalOrDepartureTime: 'Arrival',
         stopSequence: 21
       }]
     };
     missing_trip_edge_arrival_time_departure_time(params);
-    const output = '<p class="error">Error - Missing arrival or departure time for trip(s)!</p>\
+    const output =
+        '<p class="error">Error - Missing arrival or departure time for trip(s)!</p>\
 <p>Description: The first and last stop for each trip should have both an arrival and departure time.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -352,7 +355,7 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
-  /** 
+  /**
    * Test for overlapping frequency
    * */
   it('should issue overlapping frequency error', function() {
@@ -360,15 +363,16 @@ than one `agency_lang`, that\'s an error</p>\
       code: 'overlapping_frequency',
       totalNotices: 1,
       notices: [{
-        tripId: "Trip1",
+        tripId: 'Trip1',
         prevCsvRowNumber: 18,
-        prevEndTime: "18:00:00",
+        prevEndTime: '18:00:00',
         currCsvRowNumber: 19,
-        currStartTime:  "18:00:00"
+        currStartTime: '18:00:00'
       }]
     };
     overlapping_frequency(params);
-    const output = '<p class="error">Error - Overlapping frequency entries found!</p>\
+    const output =
+        '<p class="error">Error - Overlapping frequency entries found!</p>\
 <p>Description: Two frequency entries referring to the same trip may not have an overlapping time range.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -725,7 +729,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     start_and_end_time_out_of_order(params);
     const output =
-        '<div><p class="error">Error - Start and end time out of order!</p>\
+        '<div><button data-toggle="collapse" data-target="#startAndEndTimeOutOfOrder" class="error collapsed">Error - Start and end time out of order!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="startAndEndTimeOutOfOrder">\
 <p>Description: start_time is after the end_time for a row in frequencies.txt.</p>\
 <p><b>1</b> found:</p>\
 <table>\
@@ -737,7 +742,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please adjust the start time or end time of the entity!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -619,7 +619,8 @@ than one `agency_lang`, that\'s an error</p>\
        };
        stop_time_with_arrival_before_previous_departure_time(params);
        const output =
-           '<div><p class=\"error"\>Error - Stop time with arrival before previous departure time!</p>\
+           '<div><button data-toggle="collapse" data-target="#stopTimeWithArrivalBeforePreviousDepartureTime" class="error collapsed">Error - Stop time with arrival before previous departure time!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="stopTimeWithArrivalBeforePreviousDepartureTime">\
 <p>Description: Arrival for the stop time is before its corresponding previous departure time.</p>\
 <p><b>2</b> found:</p>\
 <table>\
@@ -631,7 +632,7 @@ than one `agency_lang`, that\'s an error</p>\
 <tr><td>28</td><td>26</td><td>tripV</td><td>07:18:15</td><td>07:18:00</td></tr>\
 </tbody>\
 </table>\
-<p>Please fix the arrival time or the previous departure time for the stop time!</p><br><br></div>'
+<p>Please fix the arrival time or the previous departure time for the stop time!</p><br><br></div></div>'
        expect(document.getElementById('error').innerHTML).toContain(output);
      });
 


### PR DESCRIPTION
For 3 notices: StopTimeWithArrivalBeforePreviousDepartureTimeNotice; StationWithParentStationNotice; StartAndEndTimeOutOfOrderNotice.

Soy templates are adjusted a bit at the very beginning for each notice. Tests' html contents are changed a little according to that. Auto-formatting has been run through.

```
<button data-toggle="collapse" data-target="#xxxxxxxxxx" class="???? collapsed">???? - xxxxx!<span>+</span><p>-</p></button>
<div class="content collapse in" id="xxxxxxxxxx">
  ..........
</div>
```