### PR TITLE
Adjust templates to make notices collapsable 4

### DIFF
--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -778,31 +778,33 @@
  */
 {template .startAndEndDateOutOfOrder}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Start and end date out of order!</p>
-  <p>Description: Start date is later than the end date.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>File Name</th>
-        <th>CSV Row Number</th>
-        <th>Start Date</th>
-        <th>End Date</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#startAndEndDateOutOfOrder" class="error collapsed">Error - Start and end date out of order!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="startAndEndDateOutOfOrder">
+    <p>Description: Start date is later than the end date.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.filename}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.startDate}</td>
-          <td>{$notice.endDate}</td>
+          <th>File Name</th>
+          <th>CSV Row Number</th>
+          <th>Start Date</th>
+          <th>End Date</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please adjust the start or the end date!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.filename}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.startDate}</td>
+            <td>{$notice.endDate}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please adjust the start or the end date!</p>
+    <br><br>
+  </div>
 {/template}
 
 /**
@@ -811,31 +813,33 @@
  */
 {template .sameNameAndDescriptionForRoute}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Same route name and description!</p>
-  <p>Description: Name and description of the route are the same.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>File Name</th>
-        <th>Route ID</th>
-        <th>CSV Row Number</th>
-        <th>Route Description</th>
-        <th>Specified Field</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#sameNameAndDescriptionForRoute" class="error collapsed">Error - Same route name and description!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="sameNameAndDescriptionForRoute">
+    <p>Description: Name and description of the route are the same.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.filename}</td>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.csvRowNumber}</td>
-          <td>{$notice.routeDesc}</td>
-          <td>{$notice.specifiedField}</td>
+          <th>File Name</th>
+          <th>Route ID</th>
+          <th>CSV Row Number</th>
+          <th>Route Description</th>
+          <th>Specified Field</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please adjust the specified name or the description of the route to make them different!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.filename}</td>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.csvRowNumber}</td>
+            <td>{$notice.routeDesc}</td>
+            <td>{$notice.specifiedField}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please adjust the specified name or the description of the route to make them different!</p>
+    <br><br>
+  </div>
 {/template}

--- a/webapp/src/main/webapp/resources/template.soy
+++ b/webapp/src/main/webapp/resources/template.soy
@@ -667,39 +667,41 @@
  */
 {template .routeUniqueNames}
 {let $numNotices: length($notices)/}
-  <p class="error">Error - Route without unique names!</p>
-  <p>Description: The combination of long name, short name, route type and agency ID for a route is not unique.</p>
-  <p><b>{$numNotices}</b> found:</p>
-  <table>
-    <thead>
-      <tr>
-        <th>Route ID</th>
-        <th>Route CSV Row Number</th>
-        <th>Compared Route ID</th>
-        <th>Compared Route CSV Row Number</th>
-        <th>Route Long Name</th>
-        <th>Route Short Name</th>
-        <th>Route Type</th>
-        <th>Agency ID</th>
-      </tr>
-    </thead>
-    <tbody>
-      {foreach $notice in $notices}
+  <button data-toggle="collapse" data-target="#routeUniqueNames" class="error collapsed">Error - Route without unique names!<span>+</span><p>-</p></button>
+  <div class="content collapse in" id="routeUniqueNames">
+    <p>Description: The combination of long name, short name, route type and agency ID for a route is not unique.</p>
+    <p><b>{$numNotices}</b> found:</p>
+    <table>
+      <thead>
         <tr>
-          <td>{$notice.routeId}</td>
-          <td>{$notice.routeCsvRowNumber}</td>
-          <td>{$notice.comparedRouteId}</td>
-          <td>{$notice.comparedRouteCsvRowNumber}</td>
-          <td>{$notice.routeLongName}</td>
-          <td>{$notice.routeShortName}</td>
-          <td>{$notice.routeType}</td>
-          <td>{$notice.agencyId}</td>
+          <th>Route ID</th>
+          <th>Route CSV Row Number</th>
+          <th>Compared Route ID</th>
+          <th>Compared Route CSV Row Number</th>
+          <th>Route Long Name</th>
+          <th>Route Short Name</th>
+          <th>Route Type</th>
+          <th>Agency ID</th>
         </tr>
-      {/foreach}
-    </tbody>
-  </table>
-  <p>Please change the long name or short name of the route to make it unique!</p>
-  <br><br>
+      </thead>
+      <tbody>
+        {foreach $notice in $notices}
+          <tr>
+            <td>{$notice.routeId}</td>
+            <td>{$notice.routeCsvRowNumber}</td>
+            <td>{$notice.comparedRouteId}</td>
+            <td>{$notice.comparedRouteCsvRowNumber}</td>
+            <td>{$notice.routeLongName}</td>
+            <td>{$notice.routeShortName}</td>
+            <td>{$notice.routeType}</td>
+            <td>{$notice.agencyId}</td>
+          </tr>
+        {/foreach}
+      </tbody>
+    </table>
+    <p>Please change the long name or short name of the route to make it unique!</p>
+    <br><br>
+  </div>
 {/template}
 
 /**

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -670,7 +670,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     route_unique_names(params);
     const output =
-        '<div><p class="error">Error - Route without unique names!</p>\
+        '<div><button data-toggle="collapse" data-target="#routeUniqueNames" class="error collapsed">Error - Route without unique names!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="routeUniqueNames">\
 <p>Description: The combination of long name, short name, route type and agency ID for a route is not unique.</p>\
 <p><b>2</b> found:</p>\
 <table>\
@@ -683,7 +684,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please change the long name or short name of the route to make it unique!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -768,7 +768,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     start_and_end_date_out_of_order(params);
     const output =
-        '<div><p class="error">Error - Start and end date out of order!</p>\
+        '<div><button data-toggle="collapse" data-target="#startAndEndDateOutOfOrder" class="error collapsed">Error - Start and end date out of order!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="startAndEndDateOutOfOrder">\
 <p>Description: Start date is later than the end date.</p>\
 <p><b>2</b> found:</p>\
 <table>\
@@ -781,7 +782,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please adjust the start or the end date!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 
@@ -809,7 +810,8 @@ than one `agency_lang`, that\'s an error</p>\
     };
     same_route_name_and_description(params);
     const output =
-        '<div><p class="error">Error - Same route name and description!</p>\
+        '<div><button data-toggle="collapse" data-target="#sameNameAndDescriptionForRoute" class="error collapsed">Error - Same route name and description!<span>+</span><p>-</p></button>\
+<div class="content collapse in" id="sameNameAndDescriptionForRoute">\
 <p>Description: Name and description of the route are the same.</p>\
 <p><b>2</b> found:</p>\
 <table>\
@@ -822,7 +824,7 @@ than one `agency_lang`, that\'s an error</p>\
 </tbody>\
 </table>\
 <p>Please adjust the specified name or the description of the route to make them different!</p>\
-<br><br></div>';
+<br><br></div></div>';
     expect(document.getElementById('error').innerHTML).toContain(output);
   });
 


### PR DESCRIPTION
For 3 notices: StartAndEndDateOutOfOrderNotice; SameNameAndDescriptionForRouteNotice; RouteUniqueNamesNotice.

Soy templates are adjusted a bit at the very beginning for each notice. Tests' html contents are changed a little according to that. Auto-formatting has been run through.

```
<button data-toggle="collapse" data-target="#xxxxxxxxxx" class="???? collapsed">???? - xxxxx!<span>+</span><p>-</p></button>
<div class="content collapse in" id="xxxxxxxxxx">
  ..........
</div>
```