### PR TITLE
Add visibility and headings to error and warning sections

### DIFF
--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -25,8 +25,8 @@
         <button class="btn btn-outline-primary" type="submit" id="uploadButton">Upload</button>
       </form>
       <div id="errorOutput"></div>
-      <div id="error"></div>
-      <div id="warning"></div>
+      <div id="error" style="visibility:hidden"></div>
+      <div id="warning" style="visibility:hidden"></div>
       <div id="unimplementedNotices"></div>
       <div id="allGood" style="visibility:hidden">
         <h4>All good!</h4>

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -25,11 +25,17 @@
         <button class="btn btn-outline-primary" type="submit" id="uploadButton">Upload</button>
       </form>
       <div id="errorOutput"></div>
-      <div id="error" style="visibility:hidden"></div>
-      <div id="warning" style="visibility:hidden"></div>
+      <div id="errorSection" style="visibility:hidden">
+        <h4 class='errorTitle'>Error</h4>
+        <div id="error"></div>
+      </div>
+      <div id="warningSection" style="visibility:hidden">
+        <h4 class='warningTitle'>Warning</h4>
+        <div id="warning"></div>
+      </div>
       <div id="unimplementedNotices"></div>
       <div id="allGood" style="visibility:hidden">
-        <h4>All good!</h4>
+        <h3 class='allGoodSection'>All good!</h3>
       </div>
     </div>
   </body>

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -26,11 +26,11 @@
       </form>
       <div id="errorOutput"></div>
       <div id="errorSection" style="visibility:hidden">
-        <h4 class='errorTitle'>Error</h4>
+        <h4 class='errorHeading'>Errors</h4>
         <div id="error"></div>
       </div>
       <div id="warningSection" style="visibility:hidden">
-        <h4 class='warningTitle'>Warning</h4>
+        <h4 class='warningHeading'>Warnings</h4>
         <div id="warning"></div>
       </div>
       <div id="unimplementedNotices"></div>

--- a/webapp/src/main/webapp/index.html
+++ b/webapp/src/main/webapp/index.html
@@ -28,10 +28,12 @@
       <div id="errorSection" style="visibility:hidden">
         <h4 class='errorHeading'>Errors</h4>
         <div id="error"></div>
+        <br>
       </div>
       <div id="warningSection" style="visibility:hidden">
         <h4 class='warningHeading'>Warnings</h4>
         <div id="warning"></div>
+        <br>
       </div>
       <div id="unimplementedNotices"></div>
       <div id="allGood" style="visibility:hidden">

--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -26,6 +26,13 @@ function callCorrespondingFunction(noticesJSON) {
       unimplementedNoticesArray.push(JSON.stringify(notice));
     }
   }
+  // Dynamically set the error/warning section visible if at least one error/warning is generated
+  if (document.getElementById('error').innerHTML !== '') {
+    document.getElementById('error').style.visibility = 'visible';
+  }
+  if (document.getElementById('warning').innerHTML !== '') {
+    document.getElementById('warning').style.visibility = 'visible';
+  }
   // Print all unimplemented notices as raw JSON in the unimplemented notices
   // container
   if (unimplementedNoticesArray.length !== 0) {

--- a/webapp/src/main/webapp/resources/output.js
+++ b/webapp/src/main/webapp/resources/output.js
@@ -26,12 +26,13 @@ function callCorrespondingFunction(noticesJSON) {
       unimplementedNoticesArray.push(JSON.stringify(notice));
     }
   }
-  // Dynamically set the error/warning section visible if at least one error/warning is generated
-  if (document.getElementById('error').innerHTML !== '') {
-    document.getElementById('error').style.visibility = 'visible';
+  // Dynamically set the error_section/warning_section visible if at least one
+  // error/warning is generated
+  if (document.getElementById('error').childNodes.length >= 1) {
+    document.getElementById('errorSection').style.visibility = 'visible';
   }
-  if (document.getElementById('warning').innerHTML !== '') {
-    document.getElementById('warning').style.visibility = 'visible';
+  if (document.getElementById('warning').childNodes.length >= 1) {
+    document.getElementById('warningSection').style.visibility = 'visible';
   }
   // Print all unimplemented notices as raw JSON in the unimplemented notices
   // container

--- a/webapp/src/main/webapp/script.js
+++ b/webapp/src/main/webapp/script.js
@@ -49,7 +49,9 @@ function clearNoticeContainers() {
   unimplementedNotices.innerHTML = '';
 }
 
-function clearAllGood() {
+function hideVisibleSection() {
+  document.getElementById('error').style.visibility = 'hidden';
+  document.getElementById('warning').style.visibility = 'hidden';
   document.getElementById('allGood').style.visibility = 'hidden';
 }
 
@@ -71,7 +73,7 @@ window.onload = function() {
 
     this.clearNoticeContainers();
 
-    this.clearAllGood();
+    this.hideVisibleSection();
 
     errorOutput.parentNode.insertBefore(
         loadingSpinner, errorOutput.nextSibling);

--- a/webapp/src/main/webapp/script.js
+++ b/webapp/src/main/webapp/script.js
@@ -50,8 +50,8 @@ function clearNoticeContainers() {
 }
 
 function hideVisibleSection() {
-  document.getElementById('error').style.visibility = 'hidden';
-  document.getElementById('warning').style.visibility = 'hidden';
+  document.getElementById('errorSection').style.visibility = 'hidden';
+  document.getElementById('warningSection').style.visibility = 'hidden';
   document.getElementById('allGood').style.visibility = 'hidden';
 }
 

--- a/webapp/src/main/webapp/style.css
+++ b/webapp/src/main/webapp/style.css
@@ -43,11 +43,11 @@ td, th {
   text-align: center;
 }
 
-.errorTitle {
+.errorHeading {
   color: red;
 }
 
-.warningTitle {
+.warningHeading {
   color: #ff7003;
 }
 

--- a/webapp/src/main/webapp/style.css
+++ b/webapp/src/main/webapp/style.css
@@ -37,10 +37,18 @@ td, th {
   color: white;
 }
 
-h4 {
+.allGoodSection {
   background: green;
   color: white;
   text-align: center;
+}
+
+.errorTitle {
+  color: red;
+}
+
+.warningTitle {
+  color: #ff7003;
 }
 
 .content {

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -4,8 +4,11 @@
 describe('Output', function() {
   // inject the HTML fixture for the tests
   beforeEach(function() {
-    var fixture =
-        '<div id="fixture"><div id="errorOutput"></div><div id="error"></div><div id="warning">\
+    var fixture = '<div id="fixture"><div id="errorOutput"></div>\
+        <div id="errorSection" style="visibility:hidden">\
+        <div id="error"></div></div>\
+        <div id="warningSection" style="visibility:hidden">\
+        <div id="warning"></div></div>\
                   </div><div id="unimplementedNotices"></div>\
                   <div id="allGood" style="visibility:hidden">\
                   <h4>All good!</h4></div></div>';
@@ -1087,6 +1090,10 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('error').innerHTML).toContain(errorOutput);
     expect(document.getElementById('warning').innerHTML)
         .toContain(warningOutput);
+    expect(document.getElementById('errorSection').style.visibility)
+        .toBe('visible');
+    expect(document.getElementById('warningSection').style.visibility)
+        .toBe('visible');
     expect(document.getElementById('allGood').style.visibility).toBe('hidden');
   });
 
@@ -1101,12 +1108,63 @@ than one `agency_lang`, that\'s an error</p>\
     callCorrespondingFunction(JSON.stringify(params));
     expect(document.getElementById('unimplementedNotices').innerHTML)
         .toContain(JSON.stringify(params.notices[0]));
+    expect(document.getElementById('errorSection').style.visibility)
+        .toBe('hidden');
+    expect(document.getElementById('warningSection').style.visibility)
+        .toBe('hidden');
     expect(document.getElementById('allGood').style.visibility).toBe('hidden');
   });
 
-  it('should make all_good visible if no notice is generated', function() {
+  it('should make only all_good visible if no notice is generated', function() {
     const params = {notices: []};
     callCorrespondingFunction(JSON.stringify(params));
+    expect(document.getElementById('errorSection').style.visibility)
+        .toBe('hidden');
+    expect(document.getElementById('warningSection').style.visibility)
+        .toBe('hidden');
     expect(document.getElementById('allGood').style.visibility).toBe('visible');
   });
+
+  it('should make only error section visible if only an error is generated',
+     function() {
+       const params = {
+         notices: [{
+           code: 'invalid_row_length',
+           totalNotices: 13,
+           notices: [{
+             filename: 'stop_times.txt',
+             csvRowNumber: 17,
+             rowLength: 5,
+             headerCount: 9
+           }]
+         }]
+       };
+       callCorrespondingFunction(JSON.stringify(params));
+       expect(document.getElementById('errorSection').style.visibility)
+           .toBe('visible');
+       expect(document.getElementById('warningSection').style.visibility)
+           .toBe('hidden');
+       expect(document.getElementById('allGood').style.visibility)
+           .toBe('hidden');
+     });
+
+  it('should make only warning section visible if only a warning is generated',
+     function() {
+       const params = {
+         notices: [{
+           code: 'unknown_column',
+           totalNotices: 1,
+           notices: [
+             {filename: 'stop_times.txt', fieldName: 'drop_off_time', index: 8}
+           ]
+         }]
+       };
+       callCorrespondingFunction(JSON.stringify(params));
+       expect(document.getElementById('errorSection').style.visibility)
+           .toBe('hidden');
+       expect(document.getElementById('warningSection').style.visibility)
+           .toBe('visible');
+       expect(document.getElementById('allGood').style.visibility)
+           .toBe('hidden');
+     });
 });

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -11,7 +11,7 @@ describe('Output', function() {
         <div id="warning"></div></div>\
         </div><div id="unimplementedNotices"></div>\
         <div id="allGood" style="visibility:hidden">\
-        <h4>All good!</h4></div></div>';
+        <h3 class="allGoodSection">All good!</h3></div></div>';
     document.body.insertAdjacentHTML('afterbegin', fixture);
   });
 

--- a/webapp/src/main/webapp/test/output.test.js
+++ b/webapp/src/main/webapp/test/output.test.js
@@ -9,9 +9,9 @@ describe('Output', function() {
         <div id="error"></div></div>\
         <div id="warningSection" style="visibility:hidden">\
         <div id="warning"></div></div>\
-                  </div><div id="unimplementedNotices"></div>\
-                  <div id="allGood" style="visibility:hidden">\
-                  <h4>All good!</h4></div></div>';
+        </div><div id="unimplementedNotices"></div>\
+        <div id="allGood" style="visibility:hidden">\
+        <h4>All good!</h4></div></div>';
     document.body.insertAdjacentHTML('afterbegin', fixture);
   });
 
@@ -1125,7 +1125,7 @@ than one `agency_lang`, that\'s an error</p>\
     expect(document.getElementById('allGood').style.visibility).toBe('visible');
   });
 
-  it('should make only error section visible if only an error is generated',
+  it('should make only error section visible if a single error is generated',
      function() {
        const params = {
          notices: [{
@@ -1148,7 +1148,7 @@ than one `agency_lang`, that\'s an error</p>\
            .toBe('hidden');
      });
 
-  it('should make only warning section visible if only a warning is generated',
+  it('should make only warning section visible if a single warning is generated',
      function() {
        const params = {
          notices: [{


### PR DESCRIPTION
I have set the error and warning sections to have visibility as well separately, and added headings to these two sections. Only when a warning is included in our generated notices, the "Warnings" heading will appear. Same for the "Errors" section.
I have already manually tested it. Corresponding JavaScript tests are also added. 